### PR TITLE
Fixed stop timeout

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -923,7 +923,7 @@ function NewScheduleRecord(stationName, condType, condComp, itemlist, countOverr
     end
 
     if stop_timeout > 0 then -- if stop_timeout is set add time passed condition
-      record.wait_conditions[#record.wait_conditions+1] = {type = "time", compare_type = "or", ticks = stop_timeout } -- send stuck trains away
+      record.wait_conditions[#record.wait_conditions+1] = {type = "inactivity", compare_type = "or", ticks = stop_timeout } -- send stuck trains away
     end
   elseif condType == "inactivity" then
     record.wait_conditions[#record.wait_conditions+1] = {type = condType, compare_type = "and", ticks = condComp }


### PR DESCRIPTION
ltn-dispatcher-stop-timeout is described as 'stop **inactivity** timeout' however the inactivity isn't taken into account. The train automatically left after this much time, rather than after this much inactivity. Now it needs to be inactive.