### PR TITLE
Fluid wagons have only 1 fluid box in 0.16.7

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1742,9 +1742,7 @@ local function getWagonCapacity(entity)
   if entity.type == "cargo-wagon" then
     capacity = entity.prototype.get_inventory_size(defines.inventory.cargo_wagon)
   elseif entity.type == "fluid-wagon" then
-    for n=1, #entity.fluidbox do
-      capacity = capacity + entity.fluidbox.get_capacity(n)
-    end
+    capacity = capacity + entity.fluidbox.get_capacity(1)
   end
   global.WagonCapacity[entity.name] = capacity
   return capacity


### PR DESCRIPTION
After updating to 0.16.7 I'm getting the following error when using fluid wagons:

```
 568.385 Error MainLoop.cpp:1013: Exception at tick 2088665: Error while running event LogisticTrainNetwork::on_train_changed_state (ID 23)
Passed index is out of range.
stack traceback:
	__LogisticTrainNetwork__/control.lua:1746: in function 'getWagonCapacity'
	__LogisticTrainNetwork__/control.lua:1761: in function 'GetTrainCapacity'
	__LogisticTrainNetwork__/control.lua:343: in function 'TrainArrives'
	__LogisticTrainNetwork__/control.lua:459: in function <__LogisticTrainNetwork__/control.lua:456>
```

This is due to the fact that 0.16.7 has changed the fluid wagons to only have 1 fluid box, where they used to have 3 separate boxes.

Strangely enough `#entity.fluidbox` still returns `3` but trying to access the value gives the `Passed index out of range` error.