### PR TITLE
Added check on rename for smart-display-mapmark

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -760,8 +760,7 @@ script.on_event(defines.events.on_entity_renamed, function(event)
   local uid = event.entity.unit_number
   local oldName = event.old_name
   local newName = event.entity.backer_name
-
-  if event.entity.type == "train-stop" then
+  if event.entity.type == "train-stop" and event.entity.name ~= "smart-display-mapmark" then
     RemoveStopName(uid, oldName)
     AddStopName(uid, newName)
   end


### PR DESCRIPTION
added check for entity name smart-display-mapmark to on_entity_renamed event, was causing nil error before "expecting table, got nil" this fixxed the compatibility issues, didn't fix the root cause for as far as I'm aware of, couldn't figure that out.
Thing to note, I didn't check these changes for adverse effects, just know that it works to fix a crash I had earlier.


The complete bug in question is:

Error while running event SmartDisplayRedux::on_tick (ID 0)
Error while running event LogisticTrainNetwork::on_entity_renamed (ID 57)
LogisticTrainNetwork/control.lua:521: bad argument #1 to 'next' (table expected, got nil)
stack traceback:
SmartDisplayRedux/control.lua:220: in function 'update_display'
SmartDisplayRedux/control.lua:582: in function <SmartDisplayRedux/control.lua:573>