### PR TITLE
Display "no train found"-messages at most once every two minutes.

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -29,6 +29,7 @@ local ControlSignals = {
 }
 
 local dispatcher_update_interval = 60
+local last_no_train_found_notification = 0
 
 local ErrorCodes = {
   [-1] = "white", -- not initialized
@@ -1199,7 +1200,12 @@ function ProcessRequest(reqIndex, request)
   -- TODO: rewrite train into availableTrains[train.id]
   local train = getFreeTrain(providerStation, minTraincars, maxTraincars, loadingList[1].type, totalStacks)
   if not train then
-    if message_level >= 2 then printmsg({"ltn-message.no-train-found-merged", tostring(minTraincars), tostring(maxTraincars), tostring(totalStacks), matched_network_id_string}, requestForce, true) end
+    if message_level >= 2 then
+      if last_no_train_found_notification + 7200 < game.tick then
+        printmsg({"ltn-message.no-train-found-merged", tostring(minTraincars), tostring(maxTraincars), tostring(totalStacks), matched_network_id_string}, requestForce, true)
+        last_no_train_found_notification = game.tick
+      end
+    end
     if debug_log then log("No train with "..tostring(minTraincars).." <= length <= "..tostring(maxTraincars).." to transport "..tostring(totalStacks).." stacks in network "..matched_network_id_string.." found in Depot.") end
     return nil
   end


### PR DESCRIPTION
This pull request adresses the issue described in https://forums.factorio.com/viewtopic.php?f=214&t=60628

The issue described in the forum post is that "no train found" messages are spammed once every second whenever there are no trains of a certain type available in any depot. furthermore for every message an an annoying beep is sounded every second and the wall of text prohibits a clean view of the screen.

Opteras solution "The solution is to have enough trains to satisfy demand" is not a viable one for me, because in my opinion the the amount of trains should be chosen based on average usage and not peak usage,

Also I do find these messages informative and helpful, so I do not want to disable them entirely.

So I came up with the compromise solution to restrict the display of the messages to one every two minutes. This prohibits the message spam and allows the player to view the surroundings in a regular way, even when no trains are available.
