### PR TITLE
Avoid nil error when station is renamed during build

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -517,11 +517,11 @@ function RemoveStopName(stopID, stopName)
         -- log("removed "..stopID.." from "..stopName)
       end
     end
-  end
-  if not next(global.TrainStopNames[stopName]) then
-    -- remove name-id entry
-    global.TrainStopNames[stopName] = nil
-    -- log("removed entry "..stopName..": "..stopID)
+    if not next(global.TrainStopNames[stopName]) then
+      -- remove name-id entry
+      global.TrainStopNames[stopName] = nil
+      -- log("removed entry "..stopName..": "..stopID)
+    end
   end
 end
 


### PR DESCRIPTION
If a station has its `backer_name` changed during its build event by another mod (such as https://mods.factorio.com/mod/SensibleStationNames), LTN throws a nil error due to the rename event firing and checking whether to delete the old name from `global.TrainStopNames[stopName]` when LTN hasn't seen that stop name yet.

Moving the check for deletion of the table within the block that verified the table's existence seems to avoid this condition without breaking anything else.