### PR TITLE
- added optional circuit conditions to schedules

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,13 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.8.0
+Date: 17.8.2018
+  Features:
+    - added optional circuit conditions to schedules
+  Changes:
+    - enabled read from train for all ltn stops by default
+    - enabled send to train for all ltn stops by default
+    - generated schedules use ≥ (ltn stops still parse > for loading list output)
+---------------------------------------------------------------------------------------------------
 Version: 1.7.13
 Date: 29.7.2018
   Features:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "LogisticTrainNetwork",
-  "version": "1.7.13",
+  "version": "1.8.0",
   "title": "LTN - Logistic Train Network",
   "author": "Optera",
   "contact": "https://forums.factorio.com/memberlist.php?mode=viewprofile&u=21729",

--- a/interface.lua
+++ b/interface.lua
@@ -3,6 +3,7 @@ message_filter_age = settings.global["ltn-interface-message-filter-age"].value
 debug_log = settings.global["ltn-interface-debug-logfile"].value
 min_requested = settings.global["ltn-dispatcher-requester-threshold"].value
 min_provided = settings.global["ltn-dispatcher-provider-threshold"].value
+schedule_cc = settings.global["ltn-dispatcher-schedule-circuit-control"].value
 depot_inactivity = settings.global["ltn-dispatcher-depot-inactivity"].value
 stop_timeout = settings.global["ltn-dispatcher-stop-timeout"].value
 delivery_timeout = settings.global["ltn-dispatcher-delivery-timeout"].value
@@ -19,8 +20,9 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
   if event.setting == "ltn-interface-debug-logfile" then debug_log = settings.global["ltn-interface-debug-logfile"].value end
   if event.setting == "ltn-dispatcher-requester-threshold" then min_requested = settings.global["ltn-dispatcher-requester-threshold"].value end
   if event.setting == "ltn-dispatcher-provider-threshold" then min_provided = settings.global["ltn-dispatcher-provider-threshold"].value end
-  if event.setting == "ltn-dispatcher-depot-inactivity" then  depot_inactivity = settings.global["ltn-dispatcher-depot-inactivity"].value end
-  if event.setting == "ltn-dispatcher-stop-timeout" then  stop_timeout = settings.global["ltn-dispatcher-stop-timeout"].value end
+  if event.setting == "ltn-dispatcher-schedule-circuit-control" then schedule_cc = settings.global["ltn-dispatcher-schedule-circuit-control"].value end
+  if event.setting == "ltn-dispatcher-depot-inactivity" then depot_inactivity = settings.global["ltn-dispatcher-depot-inactivity"].value end
+  if event.setting == "ltn-dispatcher-stop-timeout" then stop_timeout = settings.global["ltn-dispatcher-stop-timeout"].value end
   if event.setting == "ltn-dispatcher-delivery-timeout" then delivery_timeout = settings.global["ltn-dispatcher-delivery-timeout"].value end
   if event.setting == "ltn-dispatcher-finish-loading" then finish_loading = settings.global["ltn-dispatcher-finish-loading"].value end
   if event.setting == "ltn-dispatcher-requester-delivery-reset" then requester_delivery_reset = settings.global["ltn-dispatcher-requester-delivery-reset"].value end

--- a/locale/de/settings.cfg
+++ b/locale/de/settings.cfg
@@ -5,6 +5,7 @@ ltn-interface-debug-logfile=Schreibe Debug Logdatei
 
 ltn-dispatcher-requester-threshold=Mindestmenge für Anforderung
 ltn-dispatcher-provider-threshold=Mindestmenge für Anbieter
+ltn-dispatcher-schedule-circuit-control=Fahrplan Schaltungsbedinungen 
 ltn-dispatcher-depot-inactivity=Depot Inaktivität (ticks)
 ltn-dispatcher-stop-timeout=Haltestellen Time-Out (ticks)
 ltn-dispatcher-delivery-timeout=Lieferzeit Time-Out (ticks)
@@ -20,6 +21,7 @@ ltn-interface-debug-logfile=Schreibt Debug Informationen in /Factorio/factorio-c
 ltn-dispatcher-enabled=Warnung: Durch deaktivieren des Disponenten werden keine Lieferung generiert.\nVerfügbare Gegenstände werden weiterhin überwacht.
 ltn-dispatcher-requester-threshold=Mindestmenge an Artikeln um eine Lieferung auszulösen. \nKann durch Signal pro Anforderer-Haltestelle überschrieben werden.\ndefault = 1000
 ltn-dispatcher-provider-threshold=Mindestmenge an Artikeln um als Anbieter erkannt zu werden. \nKann durch Signal pro Anbieter-Haltestelle überschrieben werden.\ndefault = 1000
+ltn-dispatcher-schedule-circuit-control=Aktiviert Schaltungsbedinungen rot = 0 ODER grün ≥ 1 for alle Haltestellen.\nAchtung: Alle LTN Haltestellen müssen "an Zug senden" aktiviert und eine Schaltnetz-Verbindung haben. Sonst warten Züge ewig auf ein Signal.\ndefault = false
 ltn-dispatcher-depot-inactivity=Inaktivitätsdauer in ticks bevor Züge das Depot verlassen.\ndefault = 300 (5sec)
 ltn-dispatcher-stop-timeout=Dauer in ticks bevor Züge eine Station verlassen.\ndefault = 7200 (2min)
 ltn-dispatcher-delivery-timeout=Lieferzeit in ticks bevor Züge als vermisst gelten.\ndefault = 18000 (5min)

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -6,6 +6,7 @@ ltn-interface-debug-logfile=Enable debug log
 ltn-dispatcher-enabled=Dispatcher Enabled
 ltn-dispatcher-requester-threshold=Request Threshold
 ltn-dispatcher-provider-threshold=Provide Threshold
+ltn-dispatcher-schedule-circuit-control=Schedule circuit conditions
 ltn-dispatcher-depot-inactivity=Depot inactivity (ticks)
 ltn-dispatcher-stop-timeout=Stop timeout (ticks)
 ltn-dispatcher-delivery-timeout=Delivery timeout (ticks)
@@ -21,6 +22,7 @@ ltn-interface-debug-logfile=Write debug information to /Factorio/factorio-curren
 ltn-dispatcher-enabled=Warning: Deactivating Dispatcher stops delivery generation.\nItem levels will still be monitored.
 ltn-dispatcher-requester-threshold=Missing amount of items/fluids triggering a delivery.\nCan be overridden with signal at requesting stops.\ndefault = 1000
 ltn-dispatcher-provider-threshold=Amount of items/fluids required to act as provider.\nCan be overridden with signal at providing stops.\ndefault = 1000
+ltn-dispatcher-schedule-circuit-control=Adds circuit conditions to wait for red = 0 OR green ≥ 1 to all stops.\nWarning: All LTN stops require having "send to train" enabled and a circuit connection. Otherwise trains will be stuck waiting forever.\ndefault = false
 ltn-dispatcher-depot-inactivity=Duration in ticks of inactivity before trains leave the depot.\ndefault = 300 (5sec)
 ltn-dispatcher-stop-timeout=Duration in ticks before forcing trains out of stations.\ndefault = 7200 (2min)
 ltn-dispatcher-delivery-timeout=Duration in ticks deliveries can take before assuming the train was lost.\ndefault = 18000 (5min)

--- a/settings.lua
+++ b/settings.lua
@@ -49,9 +49,16 @@ data:extend({
     maximum_value = 4294967295, -- prevent 32bit signed overflow
   },
   {
+    type = "bool-setting",
+    name = "ltn-dispatcher-schedule-circuit-control",
+    order = "ca",
+    setting_type = "runtime-global",
+    default_value = false
+  },
+  {
     type = "int-setting",
     name = "ltn-dispatcher-depot-inactivity",
-    order = "ca",
+    order = "cb",
     setting_type = "runtime-global",
     default_value = 300, --5s
     minimum_value = 60, --1s
@@ -60,7 +67,7 @@ data:extend({
   {
     type = "int-setting",
     name = "ltn-dispatcher-stop-timeout",
-    order = "cb",
+    order = "cc",
     setting_type = "runtime-global",
     default_value = 7200, --2min
     minimum_value = 0, --0:off
@@ -69,7 +76,7 @@ data:extend({
   {
     type = "int-setting",
     name = "ltn-dispatcher-delivery-timeout",
-    order = "cc",
+    order = "cd",
     setting_type = "runtime-global",
     default_value = 18000, --5min
     minimum_value = 3600, -- 1min
@@ -78,14 +85,14 @@ data:extend({
   {
     type = "bool-setting",
     name = "ltn-dispatcher-requester-delivery-reset",
-    order = "cd",
+    order = "ce",
     setting_type = "runtime-global",
     default_value = false
   },
   {
     type = "bool-setting",
     name = "ltn-dispatcher-finish-loading",
-    order = "ce",
+    order = "cf",
     setting_type = "runtime-global",
     default_value = true
   },


### PR DESCRIPTION
  Features:
    - added optional circuit conditions to schedules    
  Changes:
    - enabled read from train for all ltn stops by default
    - enabled send to train for all ltn stops by default
    - generated schedules use ≥ (ltn stops still parse > for loading list output)