### PR TITLE
Raise on_delivery_complete when delivery times out

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1010,7 +1010,8 @@ function OnTick(event)
       elseif tick-delivery.started > delivery_timeout then
         if message_level >= 1 then printmsg({"ltn-message.delivery-removed-timeout", delivery.from, delivery.to, tick-delivery.started}, delivery.force, false) end
         if debug_log then log("(OnTick) Delivery from "..delivery.from.." to "..delivery.to.." removed. Timed out after "..tick-delivery.started.."/"..delivery_timeout.." ticks.") end
-        RemoveDelivery(trainID)
+        RemoveDelivery(trainID)        
+        script.raise_event(on_delivery_complete_event, {data = delivery})
       else
         activeDeliveryTrains = activeDeliveryTrains.." "..trainID
       end


### PR DESCRIPTION
Otherwise deliveries are just lost when they time out. I'd like to be able to add them to the history.