### PR TITLE
signal what goods to unload with a -1 count

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1964,7 +1964,7 @@ function UpdateStopOutput(trainStop)
           if c.condition and c.condition.first_signal then -- loading without mods can make first signal nil?
             if c.type == "item_count" then
               if (c.condition.comparator == "=" and c.condition.constant == 0) then --train expects to be unloaded of each of this item
-                inventory[c.condition.first_signal.name] = nil
+                inventory[c.condition.first_signal.name] = -1
               elseif c.condition.comparator == "≥" then --train expects to be loaded to x of this item
                 inventory[c.condition.first_signal.name] = c.condition.constant
               elseif c.condition.comparator == ">" then --train expects to be loaded to x of this item
@@ -1972,7 +1972,7 @@ function UpdateStopOutput(trainStop)
               end
             elseif c.type == "fluid_count" then
               if (c.condition.comparator == "=" and c.condition.constant == 0) then --train expects to be unloaded of each of this fluid
-                fluidInventory[c.condition.first_signal.name] = nil
+                fluidInventory[c.condition.first_signal.name] = -1
               elseif c.condition.comparator == "≥" then --train expects to be loaded to x of this fluid
                 fluidInventory[c.condition.first_signal.name] = c.condition.constant
               elseif c.condition.comparator == ">" then --train expects to be loaded to x of this fluid

--- a/control.lua
+++ b/control.lua
@@ -1964,7 +1964,7 @@ function UpdateStopOutput(trainStop)
           if c.condition and c.condition.first_signal then -- loading without mods can make first signal nil?
             if c.type == "item_count" then
               if (c.condition.comparator == "=" and c.condition.constant == 0) then --train expects to be unloaded of each of this item
-                inventory[c.condition.first_signal.name] = -1
+                inventory[c.condition.first_signal.name] = nil
               elseif c.condition.comparator == "≥" then --train expects to be loaded to x of this item
                 inventory[c.condition.first_signal.name] = c.condition.constant
               elseif c.condition.comparator == ">" then --train expects to be loaded to x of this item


### PR DESCRIPTION
Mark goods to be unloaded with a count of -1 at the requesting station. This simplifies station design especially for fluids where using the train content leaves fluids behind due to anything < 0.5 being rounded to 0.

A fluid station can connect it's pumps directly to the yellow constant combinator and set them to <fluid> != 0. This makes them unload the fluid if requested (count = -1) but also when a train is send manually (count = amount in train).