### PR TITLE
Allow duplicate stop names for requesters/providers

### DIFF
--- a/script/stop-update.lua
+++ b/script/stop-update.lua
@@ -182,8 +182,9 @@ function UpdateStop(stopID)
   -- .." requestThreshold:"..requestThreshold.." requestPriority:"..requestPriority.." noWarnings:"..tostring(noWarnings)
   -- .." provideThreshold:"..provideThreshold.." providePriority:"..providePriority.." lockedSlots:"..lockedSlots)
 
-  -- skip duplicated names on non depots
-  if #global.TrainStopNames[stop.entity.backer_name] ~= 1 and not isDepot then
+  -- skip duplicated names on non-depot LTN stops
+  local isDuplicate = #filter(isLogisticTrainStop, global.TrainStopNames[stop.entity.backer_name]) ~= 1
+  if isDuplicate and not isDepot then
     stop.errorCode = 2
     stop.activeDeliveries = {}
     if stop.parkedTrainID and global.Dispatcher.availableTrains[stop.parkedTrainID] then

--- a/script/utils.lua
+++ b/script/utils.lua
@@ -4,6 +4,21 @@
  * See LICENSE.md in the project directory for license information.
 --]]
 
+--filter(predicate, list)
+function filter(predicate, list)
+  output = {}
+  if list then
+    for _, v in ipairs(list) do
+      if predicate(v) then output[#output+1] = v end
+    end
+  end
+  return output
+end
+
+function isLogisticTrainStop(stopID)
+  return global.LogisticTrainStops[stopID]
+end
+
 --GetTrainCapacity(train)
 local function getCargoWagonCapacity(entity)
   local capacity = entity.prototype.get_inventory_size(defines.inventory.cargo_wagon)


### PR DESCRIPTION
...as long as there is still only 1 LTN station with that
name. I.e. still apply the uniqueness when it comes to LTN stops,
but allow any number of regular stops to have the same name as
an LTN stop and thus permit trains scheduled by LTN to be routed
to those regular stops.

This still does not allow multiple LTN stops with the same name and
if that's attempted a pink signal still shows. Thus the capability to
merge signals from multiple LTN stops is not implemented.

Works great with the Logistic Cargo Wagon mod because now for
some types of stations the stacker and loading/unloading areas
can be combined. Also allows for a greater variety of station
configurations which enhances the gameplay of LTN!


This may or may not be able to satisfy some of the feature requested here: https://forums.factorio.com/viewtopic.php?f=214&t=62262&hilit=Feature+Request%3A