### PR TITLE
Fix lamp color after error or misconfiguration is fixed and oversupply of trains

### DIFF
--- a/locale/de/base.cfg
+++ b/locale/de/base.cfg
@@ -51,7 +51,7 @@ error-duplicated-unit-number=[LTN] Fehler: doppelte unit_number __1__.
 error-stop-orientation=[LTN] Fehler: ungültige Heltestellen Ausrichtung __1__.
 error-parse-item=[LTN] Fehler: could not parse item __1__.
 error-no-stop=[LTN] Fehler: Kein Anbieter oder Anforderer gefunden.
-error-invalid-stop=[LTN] Fehler: ungültige Haltestelle __1__ entfernt.
+error-lost-stop=[LTN] Fehler: Verlorene Haltestelle __1__ wieder hinzugefügt.
 error-stop-output-truncated=[LTN] Fehler: Inventar von Zug __1__ in Haltestelle __2__ übersteigt Ausgabekapazität von __3__ um __4__ Signale.
 warning-dispatcher-disabled=[LTN] Warnung: Disponent deaktiviert. Es werden keine Lieferungen generiert.
 

--- a/locale/de/base.cfg
+++ b/locale/de/base.cfg
@@ -51,10 +51,10 @@ error-duplicated-unit-number=[LTN] Fehler: doppelte unit_number __1__.
 error-stop-orientation=[LTN] Fehler: ungültige Heltestellen Ausrichtung __1__.
 error-parse-item=[LTN] Fehler: could not parse item __1__.
 error-no-stop=[LTN] Fehler: Kein Anbieter oder Anforderer gefunden.
-error-lost-stop=[LTN] Fehler: Verlorene Haltestelle __1__ wieder hinzugefügt.
 error-stop-output-truncated=[LTN] Fehler: Inventar von Zug __1__ in Haltestelle __2__ übersteigt Ausgabekapazität von __3__ um __4__ Signale.
 error-invalid-delivery=[LTN] Fehler: Entferne ungültige Lieferung von Haltestelle __1__
 warning-dispatcher-disabled=[LTN] Warnung: Disponent deaktiviert. Es werden keine Lieferungen generiert.
+warning-missing-stop-name=[LTN] Warnung: Haltestelle __1__ nicht in stop Namensliste, hinzugefügt und übersprungen.
 
 empty-depot-item=[LTN] Kein Zug für Stückgut in Depots gefunden. Verarbeitung von Stückgut übersprungen
 empty-depot-fluid=[LTN] Kein Zug für Flüssigkeiten in Depots gefunden. Verarbeitung von Flüssigkeiten übersprungen

--- a/locale/de/base.cfg
+++ b/locale/de/base.cfg
@@ -53,6 +53,7 @@ error-parse-item=[LTN] Fehler: could not parse item __1__.
 error-no-stop=[LTN] Fehler: Kein Anbieter oder Anforderer gefunden.
 error-lost-stop=[LTN] Fehler: Verlorene Haltestelle __1__ wieder hinzugefügt.
 error-stop-output-truncated=[LTN] Fehler: Inventar von Zug __1__ in Haltestelle __2__ übersteigt Ausgabekapazität von __3__ um __4__ Signale.
+error-invalid-delivery=[LTN] Fehler: Entferne ungültige Lieferung von Haltestelle __1__
 warning-dispatcher-disabled=[LTN] Warnung: Disponent deaktiviert. Es werden keine Lieferungen generiert.
 
 empty-depot-item=[LTN] Kein Zug für Stückgut in Depots gefunden. Verarbeitung von Stückgut übersprungen

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -51,7 +51,7 @@ error-duplicated-unit-number=[LTN] Error: Duplicated unit_number __1__.
 error-stop-orientation=[LTN] Error: invalid train stop orientation __1__.
 error-parse-item=[LTN] Error: could not parse item __1__.
 error-no-stop=[LTN] Error: Couldn't get provider or requester stop.
-error-invalid-stop=[LTN] Error: Invalid stop __1__ removed.
+error-lost-stop=[LTN] Error: Lost stop __1__ readded.
 error-stop-output-truncated=[LTN] Error: Inventory of train __2__ at stop __1__ exceeds stop output limit of __3__ by __4__ signals.
 warning-dispatcher-disabled=[LTN] Warning: Dispatcher disabled. No deliveries will be created.
 

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -53,6 +53,7 @@ error-parse-item=[LTN] Error: could not parse item __1__.
 error-no-stop=[LTN] Error: Couldn't get provider or requester stop.
 error-lost-stop=[LTN] Error: Lost stop __1__ readded.
 error-stop-output-truncated=[LTN] Error: Inventory of train __2__ at stop __1__ exceeds stop output limit of __3__ by __4__ signals.
+error-invalid-delivery=[LTN] Error: Removing invalid delivery from stop __1__
 warning-dispatcher-disabled=[LTN] Warning: Dispatcher disabled. No deliveries will be created.
 
 empty-depot-item=[LTN] No train to transport items found in depots. Skipping item processing.

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -51,10 +51,10 @@ error-duplicated-unit-number=[LTN] Error: Duplicated unit_number __1__.
 error-stop-orientation=[LTN] Error: invalid train stop orientation __1__.
 error-parse-item=[LTN] Error: could not parse item __1__.
 error-no-stop=[LTN] Error: Couldn't get provider or requester stop.
-error-lost-stop=[LTN] Error: Lost stop __1__ readded.
 error-stop-output-truncated=[LTN] Error: Inventory of train __2__ at stop __1__ exceeds stop output limit of __3__ by __4__ signals.
 error-invalid-delivery=[LTN] Error: Removing invalid delivery from stop __1__
 warning-dispatcher-disabled=[LTN] Warning: Dispatcher disabled. No deliveries will be created.
+warning-missing-stop-name=[LTN] Warning: Stop __1__ not in stop namelist was added and skipped.
 
 empty-depot-item=[LTN] No train to transport items found in depots. Skipping item processing.
 empty-depot-fluid=[LTN] No train to transport fluids found in depots. Skipping fluid processing.

--- a/script/stop-update.lua
+++ b/script/stop-update.lua
@@ -78,11 +78,11 @@ function UpdateStop(stopID)
   stop.providePriority = 0
   stop.lockedSlots = 0
 
-  -- readd any stop not in name list
+  -- add missing stops to name list
   if not global.TrainStopNames[stop.entity.backer_name] then
     AddStopName(stop.entity.unit_number, stop.entity.backer_name)
-    if message_level >= 1 then printmsg({"ltn-message.error-lost-stop", stop.entity.backer_name}) end
-    if debug_log then log("(UpdateStop) Stop not in list global.TrainStopNames readded: "..stop.entity.backer_name) end
+    if message_level >= 1 then printmsg({"ltn-message.error-missing-stop-name", stop.entity.backer_name}) end
+    if debug_log then log("(UpdateStop) Missing stop name "..tostring(stop.entity.backer_name).." added to global.TrainStopNames") end
     return
   end
 

--- a/script/stop-update.lua
+++ b/script/stop-update.lua
@@ -209,7 +209,11 @@ function UpdateStop(stopID)
       end
     else
       if #stop.activeDeliveries > 0 then
-        setLamp(stop, "yellow", #stop.activeDeliveries)
+        if stop.parkedTrainID and stop.parkedTrain.valid then
+          setLamp(stop, "blue", #stop.activeDeliveries)
+        else
+          setLamp(stop, "yellow", #stop.activeDeliveries)
+        end
       else
         setLamp(stop, "green", 1)
       end

--- a/script/stop-update.lua
+++ b/script/stop-update.lua
@@ -59,12 +59,13 @@ function UpdateStop(stopID)
     global.LogisticTrainStops[stopID].parkedTrainID = nil
   end
 
-  -- remove invalid activeDeliveries -- shouldn't be necessary
-  -- for i=#stop.activeDeliveries, 1, -1 do
-    -- if not global.Dispatcher.Deliveries[stop.activeDeliveries[i]] then
-      -- table.remove(stop.activeDeliveries, i)
-    -- end
-  -- end
+  -- remove invalid activeDeliveries -- shouldn't be necessary -- only check oldest delivery
+  local nextDelivery = stop.activeDeliveries[1]
+  if nextDelivery and not global.Dispatcher.Deliveries[nextDelivery] then
+    table.remove(stop.activeDeliveries, 1)
+    if message_level >= 1 then printmsg({"ltn-message.error-invalid-delivery", stop.entity.backer_name}) end
+    if debug_log then log("(UpdateStop) Removing invalid delivery from stop '"..stop.entity.backer_name.."': "..nextDelivery) end
+  end
 
   -- reset stop parameters in case something goes wrong
   stop.minTraincars = 0

--- a/script/stop-update.lua
+++ b/script/stop-update.lua
@@ -89,7 +89,6 @@ function UpdateStop(stopID)
   -- skip short circuited stops
   if detectShortCircuit(stop) then
     stop.errorCode = 1
-    stop.activeDeliveries = {}
     if stop.parkedTrainID and global.Dispatcher.availableTrains[stop.parkedTrainID] then
       remove_available_train(stop.parkedTrainID)
     end
@@ -102,7 +101,6 @@ function UpdateStop(stopID)
   local stopCB = stop.entity.get_control_behavior()
   if stopCB and stopCB.disabled then
     stop.errorCode = 1
-    stop.activeDeliveries = {}
     if stop.parkedTrainID and global.Dispatcher.availableTrains[stop.parkedTrainID] then
       remove_available_train(stop.parkedTrainID)
     end
@@ -182,7 +180,6 @@ function UpdateStop(stopID)
   -- skip duplicated names on non depots
   if #global.TrainStopNames[stop.entity.backer_name] ~= 1 and not isDepot then
     stop.errorCode = 2
-    stop.activeDeliveries = {}
     if stop.parkedTrainID and global.Dispatcher.availableTrains[stop.parkedTrainID] then
       remove_available_train(stop.parkedTrainID)
     end
@@ -221,7 +218,6 @@ function UpdateStop(stopID)
   if isDepot then
     stop.isDepot = true
     stop.network_id = network_id
-    stop.activeDeliveries = {} -- reset delivery count in case stops are toggled
 
     -- add parked train to available trains
     if stop.parkedTrainID and stop.parkedTrain.valid then

--- a/script/stop-update.lua
+++ b/script/stop-update.lua
@@ -59,12 +59,13 @@ function UpdateStop(stopID)
     global.LogisticTrainStops[stopID].parkedTrainID = nil
   end
 
-  -- remove invalid activeDeliveries -- shouldn't be necessary -- only check oldest delivery
-  local nextDelivery = stop.activeDeliveries[1]
-  if nextDelivery and not global.Dispatcher.Deliveries[nextDelivery] then
-    table.remove(stop.activeDeliveries, 1)
-    if message_level >= 1 then printmsg({"ltn-message.error-invalid-delivery", stop.entity.backer_name}) end
-    if debug_log then log("(UpdateStop) Removing invalid delivery from stop '"..stop.entity.backer_name.."': "..nextDelivery) end
+  -- remove invalid activeDeliveries -- shouldn't be necessary
+  for i=#stop.activeDeliveries, 1, -1 do
+    if not global.Dispatcher.Deliveries[stop.activeDeliveries[i]] then
+      table.remove(stop.activeDeliveries, i)
+      if message_level >= 1 then printmsg({"ltn-message.error-invalid-delivery", stop.entity.backer_name}) end
+      if debug_log then log("(UpdateStop) Removing invalid delivery from stop '"..tostring(stop.entity.backer_name).."': "..nextDelivery) end
+    end
   end
 
   -- reset stop parameters in case something goes wrong
@@ -82,7 +83,7 @@ function UpdateStop(stopID)
   if not global.TrainStopNames[stop.entity.backer_name] then
     AddStopName(stop.entity.unit_number, stop.entity.backer_name)
     if message_level >= 1 then printmsg({"ltn-message.error-missing-stop-name", stop.entity.backer_name}) end
-    if debug_log then log("(UpdateStop) Missing stop name "..tostring(stop.entity.backer_name).." added to global.TrainStopNames") end
+    if debug_log then log("(UpdateStop) Missing stop name '"..tostring(stop.entity.backer_name).."' added to global.TrainStopNames") end
     return
   end
 

--- a/script/stop-update.lua
+++ b/script/stop-update.lua
@@ -77,15 +77,11 @@ function UpdateStop(stopID)
   stop.providePriority = 0
   stop.lockedSlots = 0
 
-  -- reject any stop not in name list
+  -- readd any stop not in name list
   if not global.TrainStopNames[stop.entity.backer_name] then
-    stop.errorCode = 2
-    stop.activeDeliveries = {}
-    if stop.parkedTrainID and global.Dispatcher.availableTrains[stop.parkedTrainID] then
-      remove_available_train(stop.parkedTrainID)
-    end
-    if message_level >= 1 then printmsg({"ltn-message.error-invalid-stop", stop.entity.backer_name}) end
-    if debug_log then log("(UpdateStop) Stop not in list global.TrainStopNames: "..stop.entity.backer_name) end
+    AddStopName(stop.entity.unit_number, stop.entity.backer_name)
+    if message_level >= 1 then printmsg({"ltn-message.error-lost-stop", stop.entity.backer_name}) end
+    if debug_log then log("(UpdateStop) Stop not in list global.TrainStopNames readded: "..stop.entity.backer_name) end
     return
   end
 


### PR DESCRIPTION
Trying to get the colors right for my multiple-stops stations patch I noticed that the colors are already wrong in some cases. Looking deeper I noticed it affects not just the colors.

First for the colors. On error the station turns red. But when the error is cleared the station becomes green even if there is a train parked at the station or on the way to the station.
My first fix was to mark the station blue if a train is still parked there. Turning a station yellow if a train is still scheduled to arrive was harder and lead me to the next problem:

Currently whenever there is a misconfiguration of a stop or a stop is a depot you reset the stop.activeDeliveries. That means any knowledge of pending trains is lost. If the problem is cleared LTN will then dispatch new trains to the station. Among others this happens every time you blueprint a station with names included. And sending too many trains causes all kinds of chaos.