### PR TITLE
Change to on_pickup_completed event

### DIFF
--- a/script/train-events.lua
+++ b/script/train-events.lua
@@ -130,6 +130,8 @@ function TrainLeaves(trainID)
     local delivery = global.Dispatcher.Deliveries[trainID]
     if stoppedTrain.train.valid and delivery then
       if delivery.from == stop.entity.backer_name then
+        delivery.pickupDone = true -- remove reservations from this delivery
+        script.raise_event(on_delivery_pickup_complete_event, {delivery = delivery, trainID = trainID})
         -- update delivery counts to train inventory
         for item, count in pairs (delivery.shipment) do
           local itype, iname = match(item, match_string)
@@ -147,9 +149,6 @@ function TrainLeaves(trainID)
             delivery.shipment[item] = nil
           end
         end
-        delivery.pickupDone = true -- remove reservations from this delivery
-        script.raise_event(on_delivery_pickup_complete_event, {delivery = delivery, trainID = trainID})
-
       elseif delivery.to == stop.entity.backer_name then
         -- signal completed delivery and remove it
         script.raise_event(on_delivery_completed_event, {delivery = delivery, trainID = trainID})


### PR DESCRIPTION
### What?
- on_pickup_completed event is raised before recalculating shipment instead of after
- event therefore contains planned shipment instead of recalculated shipment

### Why?
At the moment, LTNT can only detect items that are not part of the planned shipment as incorrect cargo. If a train leaves with too few or too many items that are part of the shipment, the shipment is recalculated and no alert is possible. I understand that some deviation between planned an actual shipment happens often and is not an alert case. But even extreme situations (e.g. nothing loaded), do not raise an alert right now.
By comparing actual cargo to planned shipment I could catch such errors.