### PR TITLE
Proposed event changes

### DIFF
--- a/script/dispatcher.lua
+++ b/script/dispatcher.lua
@@ -432,6 +432,7 @@ function ProcessRequest(reqIndex)
     if (global.Dispatcher.availableTrains_total_fluid_capacity or 0) == 0 then
       if message_level >= 2 then printmsg({"ltn-message.empty-depot-fluid"}, requestForce, true) end
       if debug_log then log("Skipping request "..requestStation.entity.backer_name.." {"..to_network_id_string.."}: "..item..". No trains available.") end
+      script.raise_event(on_train_not_found_event, {to = toID, network_id = requestStation.network_id, item = item})
       return nil
     end
   else
@@ -440,6 +441,7 @@ function ProcessRequest(reqIndex)
     if (global.Dispatcher.availableTrains_total_capacity or 0) == 0 then
       if message_level >= 2 then printmsg({"ltn-message.empty-depot-item"}, requestForce, true) end
       if debug_log then log("Skipping request "..requestStation.entity.backer_name.." {"..to_network_id_string.."}: "..item..". No trains available.") end
+      script.raise_event(on_train_not_found_event, {to = toID, network_id = requestStation.network_id, item = item})
       return nil
     end
   end
@@ -523,6 +525,7 @@ function ProcessRequest(reqIndex)
   if not selectedTrain or not trainInventorySize then
     if message_level >= 2 then printmsg({"ltn-message.no-train-found", from, to, matched_network_id_string, tostring(minTraincars), tostring(maxTraincars) }, requestForce, true) end
     if debug_log then log("No train with "..tostring(minTraincars).." <= length <= "..tostring(maxTraincars).." to transport "..tostring(totalStacks).." stacks from "..from.." to "..to.." in network "..matched_network_id_string.." found in Depot.") end
+    script.raise_event(on_train_not_found_event, {to = toID, from = fromID, network_id = requestStation.network_id, minTraincars = minTraincars, maxTraincars = maxTraincars, shipment = loadingList,  network_id = providerData.network_id})
     return nil
   end
 

--- a/script/dispatcher.lua
+++ b/script/dispatcher.lua
@@ -134,10 +134,6 @@ function OnTick(event)
   -- tick 60: reset
   else
     -- raise events for interface mods
-    -- script.raise_event(on_stops_updated_event, {data = global.LogisticTrainStops})
-    -- script.raise_event(on_dispatcher_updated_event, {data = global.Dispatcher}) -- sending whole dispatcher might not be ideal
-
-    -- raise events for interface mods
     script.raise_event(on_stops_updated_event,
       {
         logistic_train_stops = global.LogisticTrainStops,
@@ -432,7 +428,7 @@ function ProcessRequest(reqIndex)
     if (global.Dispatcher.availableTrains_total_fluid_capacity or 0) == 0 then
       if message_level >= 2 then printmsg({"ltn-message.empty-depot-fluid"}, requestForce, true) end
       if debug_log then log("Skipping request "..requestStation.entity.backer_name.." {"..to_network_id_string.."}: "..item..". No trains available.") end
-      script.raise_event(on_train_not_found_event, {to = toID, network_id = requestStation.network_id, item = item})
+      script.raise_event(on_train_not_found_event, {to = requestStation.entity.backer_name, to_id = toID, network_id = requestStation.network_id, item = item})
       return nil
     end
   else
@@ -441,7 +437,7 @@ function ProcessRequest(reqIndex)
     if (global.Dispatcher.availableTrains_total_capacity or 0) == 0 then
       if message_level >= 2 then printmsg({"ltn-message.empty-depot-item"}, requestForce, true) end
       if debug_log then log("Skipping request "..requestStation.entity.backer_name.." {"..to_network_id_string.."}: "..item..". No trains available.") end
-      script.raise_event(on_train_not_found_event, {to = toID, network_id = requestStation.network_id, item = item})
+      script.raise_event(on_train_not_found_event, {to = requestStation.entity.backer_name, to_id = toID, network_id = requestStation.network_id, item = item})
       return nil
     end
   end
@@ -525,7 +521,17 @@ function ProcessRequest(reqIndex)
   if not selectedTrain or not trainInventorySize then
     if message_level >= 2 then printmsg({"ltn-message.no-train-found", from, to, matched_network_id_string, tostring(minTraincars), tostring(maxTraincars) }, requestForce, true) end
     if debug_log then log("No train with "..tostring(minTraincars).." <= length <= "..tostring(maxTraincars).." to transport "..tostring(totalStacks).." stacks from "..from.." to "..to.." in network "..matched_network_id_string.." found in Depot.") end
-    script.raise_event(on_train_not_found_event, {to = toID, from = fromID, network_id = requestStation.network_id, minTraincars = minTraincars, maxTraincars = maxTraincars, shipment = loadingList,  network_id = providerData.network_id})
+    script.raise_event(on_train_not_found_event, {
+      to = to,
+      to_id = toID,
+      from = from,
+      from_id = fromID,
+      network_id = requestStation.network_id,
+      minTraincars = minTraincars,
+      maxTraincars = maxTraincars,
+      shipment = loadingList,
+      network_id = providerData.network_id
+    })
     return nil
   end
 
@@ -610,7 +616,16 @@ function ProcessRequest(reqIndex)
 
     if debug_log then log("  "..loadingListItem..", "..loadingList[i].count.." in "..loadingList[i].stacks.." stacks ") end
   end
-  global.Dispatcher.Deliveries[selectedTrain.id] = {force=requestForce, train=selectedTrain, started=game.tick, from=from, to=to, networkID=providerData.network_id, shipment=shipment}
+  global.Dispatcher.Deliveries[selectedTrain.id] = {
+    force = requestForce,
+    train = selectedTrain,
+    started = game.tick,
+    from = from,
+    from_id = fromID,
+    to = to,
+    to_id = toID,
+    networkID = providerData.network_id,
+    shipment = shipment}
   global.Dispatcher.availableTrains_total_capacity = global.Dispatcher.availableTrains_total_capacity - global.Dispatcher.availableTrains[selectedTrain.id].capacity
   global.Dispatcher.availableTrains_total_fluid_capacity = global.Dispatcher.availableTrains_total_fluid_capacity - global.Dispatcher.availableTrains[selectedTrain.id].fluid_capacity
   global.Dispatcher.availableTrains[selectedTrain.id] = nil

--- a/script/dispatcher.lua
+++ b/script/dispatcher.lua
@@ -427,8 +427,8 @@ function ProcessRequest(reqIndex)
     -- skip if no trains are available
     if (global.Dispatcher.availableTrains_total_fluid_capacity or 0) == 0 then
       if message_level >= 2 then printmsg({"ltn-message.empty-depot-fluid"}, requestForce, true) end
-      if debug_log then log("Skipping request "..requestStation.entity.backer_name.." {"..to_network_id_string.."}: "..item..". No trains available.") end
-      script.raise_event(on_train_not_found_event, {to = requestStation.entity.backer_name, to_id = toID, network_id = requestStation.network_id, item = item})
+      if debug_log then log("Skipping request "..to.." {"..to_network_id_string.."}: "..item..". No trains available.") end
+      script.raise_event(on_train_not_found_event, {to = to, to_id = toID, network_id = requestStation.network_id, item = item})
       return nil
     end
   else
@@ -436,8 +436,8 @@ function ProcessRequest(reqIndex)
     -- skip if no trains are available
     if (global.Dispatcher.availableTrains_total_capacity or 0) == 0 then
       if message_level >= 2 then printmsg({"ltn-message.empty-depot-item"}, requestForce, true) end
-      if debug_log then log("Skipping request "..requestStation.entity.backer_name.." {"..to_network_id_string.."}: "..item..". No trains available.") end
-      script.raise_event(on_train_not_found_event, {to = requestStation.entity.backer_name, to_id = toID, network_id = requestStation.network_id, item = item})
+      if debug_log then log("Skipping request "..to.." {"..to_network_id_string.."}: "..item..". No trains available.") end
+      script.raise_event(on_train_not_found_event, {to = to, to_id = toID, network_id = requestStation.network_id, item = item})
       return nil
     end
   end

--- a/script/dispatcher.lua
+++ b/script/dispatcher.lua
@@ -428,7 +428,7 @@ function ProcessRequest(reqIndex)
     if (global.Dispatcher.availableTrains_total_fluid_capacity or 0) == 0 then
       if message_level >= 2 then printmsg({"ltn-message.empty-depot-fluid"}, requestForce, true) end
       if debug_log then log("Skipping request "..to.." {"..to_network_id_string.."}: "..item..". No trains available.") end
-      script.raise_event(on_train_not_found_event, {to = to, to_id = toID, network_id = requestStation.network_id, item = item})
+      script.raise_event(on_dispatcher_no_train_found_event, {to = to, to_id = toID, network_id = requestStation.network_id, item = item})
       return nil
     end
   else
@@ -437,7 +437,7 @@ function ProcessRequest(reqIndex)
     if (global.Dispatcher.availableTrains_total_capacity or 0) == 0 then
       if message_level >= 2 then printmsg({"ltn-message.empty-depot-item"}, requestForce, true) end
       if debug_log then log("Skipping request "..to.." {"..to_network_id_string.."}: "..item..". No trains available.") end
-      script.raise_event(on_train_not_found_event, {to = to, to_id = toID, network_id = requestStation.network_id, item = item})
+      script.raise_event(on_dispatcher_no_train_found_event, {to = to, to_id = toID, network_id = requestStation.network_id, item = item})
       return nil
     end
   end
@@ -521,7 +521,7 @@ function ProcessRequest(reqIndex)
   if not selectedTrain or not trainInventorySize then
     if message_level >= 2 then printmsg({"ltn-message.no-train-found", from, to, matched_network_id_string, tostring(minTraincars), tostring(maxTraincars) }, requestForce, true) end
     if debug_log then log("No train with "..tostring(minTraincars).." <= length <= "..tostring(maxTraincars).." to transport "..tostring(totalStacks).." stacks from "..from.." to "..to.." in network "..matched_network_id_string.." found in Depot.") end
-    script.raise_event(on_train_not_found_event, {
+    script.raise_event(on_dispatcher_no_train_found_event, {
       to = to,
       to_id = toID,
       from = from,
@@ -530,7 +530,6 @@ function ProcessRequest(reqIndex)
       minTraincars = minTraincars,
       maxTraincars = maxTraincars,
       shipment = loadingList,
-      network_id = providerData.network_id
     })
     return nil
   end

--- a/script/interface.lua
+++ b/script/interface.lua
@@ -9,6 +9,7 @@ on_dispatcher_updated_event = script.generate_event_name()
 on_delivery_pickup_complete_event = script.generate_event_name()
 on_delivery_completed_event = script.generate_event_name()
 on_delivery_failed_event = script.generate_event_name()
+on_train_not_found_event = script.generate_event_name()
 
 
 -- ltn_interface allows mods to register for update events
@@ -18,13 +19,14 @@ remote.add_interface("logistic-train-network", {
 
   -- updates for whole dispatcher
   on_dispatcher_updated = function() return on_dispatcher_updated_event end,
-    
+
   -- update for updated deliveries after leaving provider
-  on_delivery_pickup_complete = function() return on_delivery_pickup_complete_event end,  
-  
+  on_delivery_pickup_complete = function() return on_delivery_pickup_complete_event end,
+
   -- update for completing deliveries
   on_delivery_completed = function() return on_delivery_completed_event end,
   on_delivery_failed = function() return on_delivery_failed_event end,
+  on_train_not_found = function() return on_train_not_found_event end,
 })
 
 

--- a/script/interface.lua
+++ b/script/interface.lua
@@ -6,27 +6,26 @@
 
 on_stops_updated_event = script.generate_event_name()
 on_dispatcher_updated_event = script.generate_event_name()
+on_dispatcher_no_train_found_event = script.generate_event_name()
 on_delivery_pickup_complete_event = script.generate_event_name()
 on_delivery_completed_event = script.generate_event_name()
 on_delivery_failed_event = script.generate_event_name()
-on_train_not_found_event = script.generate_event_name()
-
 
 -- ltn_interface allows mods to register for update events
 remote.add_interface("logistic-train-network", {
   -- updates for ltn_stops
   on_stops_updated = function() return on_stops_updated_event end,
 
-  -- updates for whole dispatcher
+  -- updates for dispatcher
   on_dispatcher_updated = function() return on_dispatcher_updated_event end,
+  on_dispatcher_no_train_found = function() return on_dispatcher_no_train_found_event end,
 
   -- update for updated deliveries after leaving provider
-  on_delivery_pickup_complete = function() return on_delivery_pickup_complete_event end,
+  on_delivery_pickup_complete = function() return on_delivery_pickup_complete_event end,´
 
   -- update for completing deliveries
   on_delivery_completed = function() return on_delivery_completed_event end,
   on_delivery_failed = function() return on_delivery_failed_event end,
-  on_train_not_found = function() return on_train_not_found_event end,
 })
 
 

--- a/script/train-events.lua
+++ b/script/train-events.lua
@@ -131,8 +131,10 @@ function TrainLeaves(trainID)
     if stoppedTrain.train.valid and delivery then
       if delivery.from == stop.entity.backer_name then
         -- update delivery counts to train inventory
+        local original_shipment = {}
         for item, count in pairs (delivery.shipment) do
           local itype, iname = match(item, match_string)
+          original_shipment[item] = count
           if itype and iname and (game.item_prototypes[iname] or game.fluid_prototypes[iname]) then
             if itype == "fluid" then
               local traincount = stoppedTrain.train.get_fluid_count(iname)
@@ -148,7 +150,7 @@ function TrainLeaves(trainID)
           end
         end
         delivery.pickupDone = true -- remove reservations from this delivery
-        script.raise_event(on_delivery_pickup_complete_event, {delivery = delivery, trainID = trainID})
+        script.raise_event(on_delivery_pickup_complete_event, {delivery = delivery, trainID = trainID, original_shipment = original_shipment})
 
       elseif delivery.to == stop.entity.backer_name then
         -- signal completed delivery and remove it


### PR DESCRIPTION
#### added on_train_not_found event, raised when creating a delivery fails due to finding no suitable train
Event data consists only of information already available to LTN. Will probably add an integer flag to distinguish between different causes for missing trains.

#### added to_id and from_id keys to delivery table
These are already known to LTN and allow me to stop using a name -> ID lookup table to find the stop entities for a certain delivery. This is a (small) change to LTN's data internal structure.

#### added original shipment to event data for on_delivery_pickup_complete event
Would be useful for LTNT as discussed in #172. This data is not available and needs to be created first.


This is just my first draft. Once I know which of these changes you are willing to makel, I will run a number of benchmarks to make sure LTN's performance is not impacted by these changes and if necessary adjust.