### PR TITLE
Bugfix for items missing from requests_by_stop

### DIFF
--- a/script/dispatcher.lua
+++ b/script/dispatcher.lua
@@ -523,6 +523,7 @@ function ProcessRequest(reqIndex)
     if debug_log then log("No train with "..tostring(minTraincars).." <= length <= "..tostring(maxTraincars).." to transport "..tostring(totalStacks).." stacks from "..from.." to "..to.." in network "..matched_network_id_string.." found in Depot.") end
     script.raise_event(on_dispatcher_no_train_found_event, { to = to, to_id = toID, from = from, from_id = fromID, network_id = requestStation.network_id, minTraincars = minTraincars, maxTraincars = maxTraincars, shipment = loadingList,
     })
+    global.Dispatcher.Requests_by_Stop[toID][item] = count -- add removed item back to list of requested items.
     return nil
   end
 


### PR DESCRIPTION
When experimenting with the new events, I found a minor bug. When a request is processed, items are deleted from requests_by_stop as part of the merge logic:
https://github.com/Yousei9/Logistic-Train-Network/blob/2dfebdfddfc7b06d528054ea160d6b93565199fe/script/dispatcher.lua#L486

If the delivery is scheduled successfully, that is not a problem. But if no suitable train is found, the item has to be added back to requests_by_stop . Otherwise it is missing when on_dispatcher_updated sends its data.

The change I made fixes that issue, hopefully without breaking anything.