### PR TITLE
Remove need for unique station names

### DIFF
--- a/script/stop-update.lua
+++ b/script/stop-update.lua
@@ -178,17 +178,8 @@ function UpdateStop(stopID, stop)
   -- .." requestThreshold:"..requestThreshold.." requestPriority:"..requestPriority.." noWarnings:"..tostring(noWarnings)
   -- .." provideThreshold:"..provideThreshold.." providePriority:"..providePriority.." lockedSlots:"..lockedSlots)
 
-  -- skip duplicated names on non depots
-  if #global.TrainStopNames[stop.entity.backer_name] ~= 1 and not isDepot then
-    stop.errorCode = 2
-    if stop.parkedTrainID and global.Dispatcher.availableTrains[stop.parkedTrainID] then
-      remove_available_train(stop.parkedTrainID)
-    end
-    setLamp(stop, ErrorCodes[stop.errorCode], 1)
-    if debug_log then log("(UpdateStop) Duplicate stop name: "..stop.entity.backer_name) end
-    return
-  end
-
+  -- Duplicate station names are ok
+  
   --update lamp colors when errorCode or isDepot changed state
   if stop.errorCode ~=0 or stop.isDepot ~= isDepot then
     stop.errorCode = 0 -- we are error free here
@@ -284,7 +275,7 @@ function UpdateStop(stopID, stop)
               if newcount > 0 then newcount = 0 end --make sure we don't turn it into a provider
               if debug_log then log("(UpdateStop) "..stop.entity.backer_name.." {"..network_id_string.."} updating requested count with train inventory: "..item.." "..count.."+"..traincount.."="..newcount) end
               count = newcount
-            elseif delivery.from == stop.entity.backer_name then
+            elseif delivery.from_id == stop.entity.unit_number then
               if traincount <= deliverycount then
                 local newcount = count - (deliverycount - traincount)
                 if newcount < 0 then newcount = 0 end --make sure we don't turn it into a request
@@ -304,7 +295,7 @@ function UpdateStop(stopID, stop)
               if newcount > 0 then newcount = 0 end --make sure we don't turn it into a provider
               if debug_log then log("(UpdateStop) "..stop.entity.backer_name.." {"..network_id_string.."} updating requested count with delivery: "..item.." "..count.."+"..deliverycount.."="..newcount) end
               count = newcount
-            elseif delivery.from == stop.entity.backer_name and not delivery.pickupDone then
+            elseif delivery.from_id == stop.entity.unit_number and not delivery.pickupDone then
               local newcount = count - deliverycount
               if newcount < 0 then newcount = 0 end --make sure we don't turn it into a request
               if debug_log then log("(UpdateStop) "..stop.entity.backer_name.." {"..network_id_string.."} updating provided count with delivery: "..item.." "..count.."-"..deliverycount.."="..newcount) end

--- a/script/train-events.lua
+++ b/script/train-events.lua
@@ -136,7 +136,7 @@ function TrainLeaves(trainID)
 
     local delivery = global.Dispatcher.Deliveries[trainID]
     if stoppedTrain.train.valid and delivery then
-      if delivery.from == stop.entity.backer_name then
+      if delivery.from_id == stop.entity.unit_number then
         -- update delivery counts to train inventory
         local actual_shipment = {}
         local train_items = stoppedTrain.train.get_contents()
@@ -151,7 +151,7 @@ function TrainLeaves(trainID)
         script.raise_event(on_delivery_pickup_complete_event, {train_id = trainID, planned_shipment = delivery.shipment, actual_shipment = actual_shipment})
         delivery.shipment = actual_shipment
 
-      elseif delivery.to == stop.entity.backer_name then
+      elseif delivery.to_id == stop.entity.unit_number then
         -- signal completed delivery and remove it
         script.raise_event(on_delivery_completed_event, {train_id = trainID, shipment = delivery.shipment})
         global.Dispatcher.Deliveries[trainID] = nil


### PR DESCRIPTION
Force trains to go to the correct station by adding a temp waypoint to rail under station.
Removed need to check for duplicate station names.