### PR TITLE
Add option to disable creation of temporary stops.

### DIFF
--- a/locale/de/settings.cfg
+++ b/locale/de/settings.cfg
@@ -15,6 +15,7 @@ ltn-dispatcher-stop-timeout(s)=maximale Ladedauer (Sek.)
 ltn-dispatcher-delivery-timeout(s)=maximale Lieferzeit (Sek.)
 ltn-dispatcher-requester-delivery-reset=Fahrplan bei Anforderer abschließen
 ltn-dispatcher-finish-loading=Beladung abschließen
+ltn-dispatcher-create-temporary-stops=Temporäre Haltestellen
 ltn-depot-reset-filters=Waggonfilter in Depots löschen
 ltn-depot-fluid-cleaning=Automatisch entfernte Flüssigkeitsmenge
 ltn-stop-default-network=Standard Netzwerk ID
@@ -36,6 +37,7 @@ ltn-dispatcher-stop-timeout(s)=Dauer in Sekunden bevor Züge ihre Station verlas
 ltn-dispatcher-delivery-timeout(s)=Lieferzeit in Sekunden bevor Züge als vermisst gelten.\nStandardwert = 600s (10min)
 ltn-dispatcher-requester-delivery-reset=Inaktiv: (Standardwert)\nLieferung und Fahrplan werden bei Ankunft im Depot zurück gesetzt.\nÄnderungen an Zügen in Anforderer-Haltestellen haben keine Auswirkung.\n\nAktiv:\nLieferung und Fahrplan werden bei verlassen der Anforderer-Haltestelle zurück gesetzt.\nÄnderungen an Zügen in Anforderer-Haltestellen löscht die Lieferung und setzt den Fahrplan zurück.
 ltn-dispatcher-finish-loading=Aktiv: (Standardwert)\nVerhindert verlassen von Haltestellen während Greifarme/Pumpen arbeiten.\n\nInaktiv:\nZüge verlassen Haltestellen unmittelbar nach erreichen ihrer gewünschten Beladung.\nGreifarme bleiben Gegenstände haltend stecken, Tankwaggons enthalten Restmengen.
+ltn-dispatcher-create-temporary-stops=Aktiv: (Standardwert)\nErstellt temporäre Haltestellen, damit Züge zur richtigen Haltestelle fahren, wenn es mehrere Haltestellen mit dem gleichen Namen gibt.\n\nInaktiv:\nEs werden keine temporären Haltestellen erstellt. Dies kann zur Lastverteilung genutzt werden. Wenn Haltestellen jedoch unbeabsichtigt den gleichen Namen haben, fahren Züge potentiell zur falschen Haltestelle.
 ltn-depot-reset-filters=Aktiv: (Standardwert)\nFilter und Stapelbegrenzungen in Güterwaggons werden bei Ankunft im Depot gelöscht.
 ltn-depot-fluid-cleaning=Maximale Flüssigkeitsmenge pro Waggon die bei Ankunft im Depot automatisch zerstört wird.\n0 schaltet diese Funktion aus.
 ltn-stop-default-network=Netzwerk ID wenn kein Signal "Kodierte Netzwerk ID" existiert.

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -16,6 +16,7 @@ ltn-dispatcher-stop-timeout(s)=Stop timeout (sec)
 ltn-dispatcher-delivery-timeout(s)=Delivery timeout (sec)
 ltn-dispatcher-requester-delivery-reset=Delivery completes at requester
 ltn-dispatcher-finish-loading=Finish loading
+ltn-dispatcher-create-temporary-stops=Temporary stops
 ltn-depot-reset-filters=Depots reset filters
 ltn-depot-fluid-cleaning=Depot fluid removal limit
 ltn-stop-default-network=Default network ID
@@ -37,6 +38,7 @@ ltn-dispatcher-stop-timeout(s)=Duration in seconds before trains are forced out 
 ltn-dispatcher-delivery-timeout(s)=Duration in seconds deliveries can take before assuming the train was lost.\ndefault = 600 (10min)
 ltn-dispatcher-requester-delivery-reset=False: (default)\nDelivery and schedule are reset when train arrives at depot.\nChanges to trains parked at requesting stops have no effect.\n\nTrue:\nDelivery and schedule are reset when train leaves requester.\nChanges to trains parked at requesting stops will remove delivery and reset schedule.
 ltn-dispatcher-finish-loading=True: (default)\nPrevents trains from leaving while inserters/pumps are working by adding 2s inactivity condition.\n\nFalse:\nTrains will leave immediately when all items have been loaded.\nInserters at loading stations will get stuck.
+ltn-dispatcher-create-temporary-stops=True: (default)\nCreates temporary stops to force trains to drive to the correct train stop if there are multiple train stops with the same name.\n\nFalse:\nNo temporary stops are created. This may be useful for loadbalancing but can lead to trains driving to the wrong train stop if there is accidentally another one with the same name.
 ltn-depot-reset-filters=True: (default)\nCargo wagons have their filters and stack limitations cleared when entering a depot.
 ltn-depot-fluid-cleaning=Maximum amount of fluid per wagon automatically destroyed when entering depots.\nSet to 0 to disable.
 ltn-stop-default-network=Network ID used for stops without "Encoded Network ID" signal.

--- a/script/dispatcher.lua
+++ b/script/dispatcher.lua
@@ -623,13 +623,13 @@ function ProcessRequest(reqIndex, request)
   schedule.records[#schedule.records + 1] = NewScheduleRecord(depot.entity.backer_name, "inactivity", depot_inactivity)
 
   -- force train to go to the station we pick by setting a temporary waypoint on the rail that the station is connected to
-  if fromRail then
+  if fromRail and create_temporary_stops then
     -- wait time 0 is interpreted as waypoint without stopping by Factorio
     schedule.records[#schedule.records + 1] = NewScheduleRecord(nil, "time", 0, nil, 0, fromRail)
   end
   schedule.records[#schedule.records + 1] = NewScheduleRecord(from, "item_count", "≥", loadingList)
 
-  if toRail then
+  if toRail and create_temporary_stops then
     schedule.records[#schedule.records + 1] = NewScheduleRecord(nil, "time", 0, nil, 0, toRail)
   end
   schedule.records[#schedule.records + 1] = NewScheduleRecord(to, "item_count", "=", loadingList, 0)

--- a/script/settings.lua
+++ b/script/settings.lua
@@ -17,6 +17,7 @@ stop_timeout = settings.global["ltn-dispatcher-stop-timeout(s)"].value * 60
 condition_stop_timeout = {type = "time", compare_type = "or", ticks = stop_timeout }
 delivery_timeout = settings.global["ltn-dispatcher-delivery-timeout(s)"].value * 60
 finish_loading = settings.global["ltn-dispatcher-finish-loading"].value
+create_temporary_stops = settings.global["ltn-dispatcher-create-temporary-stops"].value
 requester_delivery_reset = settings.global["ltn-dispatcher-requester-delivery-reset"].value
 dispatcher_enabled = settings.global["ltn-dispatcher-enabled"].value
 dispatcher_updates_per_tick = settings.global["ltn-dispatcher-updates-per-tick"].value
@@ -64,6 +65,9 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
   end
   if event.setting == "ltn-dispatcher-finish-loading" then
     finish_loading = settings.global["ltn-dispatcher-finish-loading"].value
+  end
+  if event.setting == "ltn-dispatcher-create-temporary-stops" then
+    create_temporary_stops = settings.global["ltn-dispatcher-create-temporary-stops"].value
   end
   if event.setting == "ltn-dispatcher-requester-delivery-reset" then
     requester_delivery_reset = settings.global["ltn-dispatcher-requester-delivery-reset"].value

--- a/settings.lua
+++ b/settings.lua
@@ -136,6 +136,13 @@ data:extend({
   },
   {
     type = "bool-setting",
+    name = "ltn-dispatcher-create-temporary-stops",
+    order = "cg",
+    setting_type = "runtime-global",
+    default_value = true
+  },
+  {
+    type = "bool-setting",
     name = "ltn-depot-reset-filters",
     order = "da",
     setting_type = "runtime-global",


### PR DESCRIPTION
This adds an option to skip the creation of temporary stops for the train schedule.

### Why?
This enables load balancing by creating additional (non-LTN) train stops with the same name as an LTN train stop.
For example, in my current [space-exploration](https://mods.factorio.com/mod/space-exploration) setup there is a train stop that requests a lot of different materials to send them to the orbit. A single train stop cannot keep up with the demand. Using multiple LTN train stops on the other hand and managing them either manually or via circuit network has flaws that I could not solve. Not using temporary stops is a solution to this problem that is simple, works similar to the base game and does not share any of those flaws. The only downside is that one has to carefully name train stops to prevent accidental naming collisions. Because of that I think the default behavior should stay the same as it is now and the proposed feature should be opt-in.

I hope it's okay that I provide a pull request for this even though it violates the license (no distribution of modifications). If not, please let me know and I'll remove the fork immediately.