### PR TITLE
add setting to change icons to images and vice versa when renaming stops

### DIFF
--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -19,6 +19,7 @@ ltn-dispatcher-finish-loading=Finish loading
 ltn-depot-reset-filters=Depots reset filters
 ltn-depot-fluid-cleaning=Depot fluid removal limit
 ltn-stop-default-network=Default network ID
+ltn-icon-texts=Use icon texts
 
 [mod-setting-description]
 ltn-interface-console-level=Detail level of in game messages.\n\n0: Off\nNo messages will be generated.\n\n1: Errors & Warnings\nPrint only errors and warnings.\n\n2: Notifications (default)\nPrint basic information like missing resources or generating deliveries.\n\n3: Detailed Messages\nPrint detailed information about finding providers and trains.
@@ -40,6 +41,7 @@ ltn-dispatcher-finish-loading=True: (default)\nPrevents trains from leaving whil
 ltn-depot-reset-filters=True: (default)\nCargo wagons have their filters and stack limitations cleared when entering a depot.
 ltn-depot-fluid-cleaning=Maximum amount of fluid per wagon automatically destroyed when entering depots.\nSet to 0 to disable.
 ltn-stop-default-network=Network ID used for stops without "Encoded Network ID" signal.
+ltn-icon-texts=When a LTN train stop or port is renamed by a player replace icons with images or images with icons. Icons will show an image followed by text in square bracked in messages while images are just the image. Will change all LTN train stops and ports once if the setting is changed.
 
 [string-mod-setting]
 #<setting-name>-<dropdown-item-name>=<translated item>
@@ -47,3 +49,7 @@ ltn-interface-console-level-0=0: Off
 ltn-interface-console-level-1=1: Errors & Warnings
 ltn-interface-console-level-2=2: Notifications
 ltn-interface-console-level-3=3: Detailed Messages
+
+ltn-icon-texts-off=Leave names alone
+ltn-icon-texts-icons=Icons with text
+ltn-icon-texts-images=Images without text

--- a/script/init.lua
+++ b/script/init.lua
@@ -173,7 +173,10 @@ local function initializeTrainStops()
     if not stop then
       log("[LTN] removing empty stop entry "..tostring(stopID) )
       global.LogisticTrainStops[stopID] = nil
-    elseif not(stop.entity and stop.entity.valid) then
+    elseif stop.entity and stop.entity.valid then
+      -- valid stop, check icon -> image conversion
+      check_stop_name(stop.entity)
+    else
       -- stop entity is corrupt/missing remove I/O entities
       log("[LTN] removing corrupt stop "..tostring(stopID) )
       if stop.input and stop.input.valid then
@@ -264,6 +267,7 @@ local function registerEvents()
   script.on_event( defines.events.script_raised_destroy, OnEntityRemoved )
 
   script.on_event( {defines.events.on_pre_surface_deleted, defines.events.on_pre_surface_cleared }, OnSurfaceRemoved )
+  script.on_event( defines.events.on_entity_renamed, stop_renamed_event )
 
   if global.LogisticTrainStops and next(global.LogisticTrainStops) then
     -- script.on_event(defines.events.on_tick, OnTick)

--- a/script/settings.lua
+++ b/script/settings.lua
@@ -27,6 +27,7 @@ end
 depot_reset_filters = settings.global["ltn-depot-reset-filters"].value
 depot_fluid_cleaning = settings.global["ltn-depot-fluid-cleaning"].value
 default_network = settings.global["ltn-stop-default-network"].value
+icon_texts = settings.global["ltn-icon-texts"].value
 
 
 script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
@@ -98,5 +99,14 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
   end
   if event.setting == "ltn-stop-default-network" then
     default_network = settings.global["ltn-stop-default-network"].value
+  end
+  if event.setting == "ltn-icon-texts" then
+    icon_texts = settings.global["ltn-icon-texts"].value
+    for stopID, stop in pairs (global.LogisticTrainStops) do
+      if stop and stop.entity and stop.entity.valid then
+      -- valid stop, check icon -> image conversion
+        check_stop_name(stop.entity)
+      end
+    end
   end
 end)

--- a/script/stop-update.lua
+++ b/script/stop-update.lua
@@ -485,3 +485,38 @@ function UpdateStopOutput(trainStop)
   end
 end
 
+-- check name of train stop for rich text and replace icons with images or vice versa
+function check_stop_name(stop)
+  if icon_texts == "icons" then
+    stop.backer_name = string.gsub(stop.backer_name, "img=item/", "item=")
+    stop.backer_name = string.gsub(stop.backer_name, "img=entity/", "entity=")
+    stop.backer_name = string.gsub(stop.backer_name, "img=technology/", "technology=")
+    stop.backer_name = string.gsub(stop.backer_name, "img=recipe/", "recipe=")
+    stop.backer_name = string.gsub(stop.backer_name, "img=item-group/", "item-group=")
+    stop.backer_name = string.gsub(stop.backer_name, "img=fluid/", "fluid=")
+    stop.backer_name = string.gsub(stop.backer_name, "img=tile/", "tile=")
+    stop.backer_name = string.gsub(stop.backer_name, "img=virtual-signal/", "virtual-signal=")
+    stop.backer_name = string.gsub(stop.backer_name, "img=achievement/", "achievement=")
+  elseif icon_texts == "images" then
+    stop.backer_name = string.gsub(stop.backer_name, "item=", "img=item/")
+    stop.backer_name = string.gsub(stop.backer_name, "entity=", "img=entity/")
+    stop.backer_name = string.gsub(stop.backer_name, "technology=", "img=technology/")
+    stop.backer_name = string.gsub(stop.backer_name, "recipe=", "img=recipe/")
+    stop.backer_name = string.gsub(stop.backer_name, "item-group=", "img=item-group/")
+    stop.backer_name = string.gsub(stop.backer_name, "fluid=", "img=fluid/")
+    stop.backer_name = string.gsub(stop.backer_name, "tile=", "img=tile/")
+    stop.backer_name = string.gsub(stop.backer_name, "virtual-signal=", "img=virtual-signal/")
+    stop.backer_name = string.gsub(stop.backer_name, "achievement=", "img=achievement/")
+  end
+end
+
+-- check stop names when they are renamed
+function stop_renamed_event(event)
+  -- don't check scripts to avoid getting into a renaming war
+  if event.by_script then return end
+  if event.entity and event.entity.valid then
+    if event.entity.name == "logistic-train-stop" or event.entity.name == "ltn-port" then
+      check_stop_name(event.entity)
+    end
+  end
+end

--- a/settings.lua
+++ b/settings.lua
@@ -156,4 +156,12 @@ data:extend({
     setting_type = "runtime-global",
     default_value = -1, -- any
   },
+  {
+    type = "string-setting",
+    name = "ltn-icon-texts",
+    order = "fa",
+    setting_type = "runtime-global",
+    default_value = "off",
+    allowed_values = {"off", "icons", "images"}
+  },
 })


### PR DESCRIPTION
Adds a new setting "Use icon texts" with 3 modes:

1. "Leave names alone" (default) does nothing.
2. "Icons with text" replaces any img= tags in the name with the respective icon form
3. "Images without text" replaces any type=name icon with the respective img=type/name form

Train stops and ports are only renamed when the on_entity_renamed event is triggered by a player. Renaming by scripts is left alone to avoid a renaming war. Names set by the game for new stops don't contain any icons I believe and I assume names set by blueprints will already be in the desired form.

All train stops and ports are renamed when the setting is changed to migrate old games or to update blueprints (place blueprint, toggle the setting, refresh blueprint).
