### PR TITLE
Fix changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,7 +20,7 @@ Date: 2021-11-07
 Version: 1.16.4
 Date: 2021-11-06
   Bugfixes:
-    -  Add handling of on_entity_cloned event #274
+    - Add handling of on_entity_cloned event #274
 ---------------------------------------------------------------------------------------------------
 Version: 1.16.3
 Date: 2021-06-30


### PR DESCRIPTION
Change notes for 1.16.4 contained an extra space, preventing them from being parsed in game.

Yes the in-game parser really is that picky.