### PR TITLE
Toggling rich text only icons without requiring stations to be renamed

### DIFF
--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -1,5 +1,6 @@
 [mod-setting-name]
 ltn-interface-console-level=Message level
+ltn-interface-message-rich-text-icons-only=Rich text show icons only
 ltn-interface-message-filter-age=Message filter timeout (ticks)
 ltn-interface-message-gps=GPS tags
 ltn-interface-factorio-alerts=Factorio Alerts
@@ -22,6 +23,7 @@ ltn-stop-default-network=Default network ID
 
 [mod-setting-description]
 ltn-interface-console-level=Detail level of in game messages.\n\n0: Off\nNo messages will be generated.\n\n1: Errors & Warnings\nPrint only errors and warnings.\n\n2: Notifications (default)\nPrint basic information like missing resources or generating deliveries.\n\n3: Detailed Messages\nPrint detailed information about finding providers and trains.
+ltn-interface-message-rich-text-icons-only=The way rich text is shown.\n\nOff: Rich icons include their green text.\n\nOn: Rich icons only show their icon.
 ltn-interface-message-filter-age=Message age in ticks before filtered messages are shown again.\ndefault = 18000
 ltn-interface-factorio-alerts=Show errors and warnings as Factorio alerts
 ltn-interface-debug-logfile=Write debug information to /Factorio/factorio-current.log.

--- a/script/settings.lua
+++ b/script/settings.lua
@@ -6,6 +6,7 @@
 --]]
 
 message_level = tonumber(settings.global["ltn-interface-console-level"].value)
+message_rich_text_icons_only = settings.global["ltn-interface-message-rich-text-icons-only"].value
 message_filter_age = settings.global["ltn-interface-message-filter-age"].value
 message_include_gps = settings.global["ltn-interface-message-gps"].value
 debug_log = settings.global["ltn-interface-debug-logfile"].value
@@ -33,6 +34,9 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
   if not event then return end
   if event.setting == "ltn-interface-console-level" then
     message_level = tonumber(settings.global["ltn-interface-console-level"].value)
+  end
+  if event.setting == "ltn-interface-message-rich-text-icons-only" then
+   message_rich_text_icons_only = settings.global["ltn-interface-message-rich-text-icons-only"].value
   end
   if event.setting == "ltn-interface-message-filter-age" then
     message_filter_age = settings.global["ltn-interface-message-filter-age"].value

--- a/script/utils.lua
+++ b/script/utils.lua
@@ -42,6 +42,10 @@ end
 
 -- returns gps string from entity or just string if entity is invalid
 function MakeGpsString(entity, name)
+  if(message_rich_text_icons_only) then
+    name = RichTextIconsOnly(name)
+  end
+
   if message_include_gps and entity and entity.valid then
     return format("%s [gps=%s,%s,%s]", name, entity.position["x"], entity.position["y"], entity.surface.name)
   else
@@ -49,3 +53,23 @@ function MakeGpsString(entity, name)
   end
 end
 
+-- removes the clickable green from rich text, only their icons stay
+local rich_text_icons_only_cache = {}
+function RichTextIconsOnly(name)
+  local key = name -- name changes here, storing the original as key
+
+  if rich_text_icons_only_cache[key] == nil then
+    name = name:gsub("%[item="           , "[img=item/")
+    name = name:gsub("%[entity="         , "[img=entity/")
+    name = name:gsub("%[technology="     , "[img=technology/")
+    name = name:gsub("%[recipe="         , "[img=recipe/")
+    name = name:gsub("%[item%-group="    , "[img=item-group/")
+    name = name:gsub("%[fluid="          , "[img=fluid/")
+    name = name:gsub("%[tile="           , "[img=tile/")
+    name = name:gsub("%[virtual%-signal=", "[img=virtual-signal/")
+    name = name:gsub("%[achievement="    , "[img=achievement/")
+    rich_text_icons_only_cache[key] = name
+  end
+
+  return rich_text_icons_only_cache[key]
+end

--- a/settings.lua
+++ b/settings.lua
@@ -38,6 +38,13 @@ data:extend({
     default_value = "2",
     allowed_values = {"0", "1", "2", "3"}
   },
+    {
+      type = "bool-setting",
+      name = "ltn-interface-message-rich-text-icons-only",
+      order = "ada",
+      setting_type = "runtime-global",
+      default_value = false
+    },
   {
     type = "int-setting",
     name = "ltn-interface-message-filter-age",


### PR DESCRIPTION
Tackling both of these by the source:
- https://github.com/Yousei9/Logistic-Train-Network/pull/280
- https://mods.factorio.com/mod/ltn-rich-text-converter

Instead of renaming the original stations, just filter it out on LTN level:
![Screen Shot 2022-01-06 at 10 03 29](https://user-images.githubusercontent.com/3179271/148359223-c585c9f4-38bc-4d41-9dd2-25f5582140ca.png)

Here's a demo message with it on & off:
![Screen Shot 2022-01-06 at 10 13 58](https://user-images.githubusercontent.com/3179271/148359291-5abc77f8-60fa-4875-92ee-1e3b6aa49530.png)

The result is cached to avoid running dozens of gsub's each time, this shouldn't cause any desync afaik 🤔 
