### PR TITLE
Output combinator only returns the query. When delivery, returns -1. …

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.16.8
+By: viidi.
+Date: 2022-06-17
+  Bugfixes:
+    - output combinator only returns the query. When delivery, returns -1. Can be disabled for backward compatible. Disabled by default.
+---------------------------------------------------------------------------------------------------
 Version: 1.16.7
 Date: 2021-11-17
   Bugfixes:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,5 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.16.8
-By: viidi.
 Date: 2022-06-17
   Bugfixes:
     - output combinator only returns the query. When delivery, returns -1. Can be disabled for backward compatible. Disabled by default.

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "LogisticTrainNetwork",
-  "version": "1.16.7",
+  "version": "1.16.8",
   "title": "LTN - Logistic Train Network",
   "author": "Optera",
   "contact": "https://forums.factorio.com/memberlist.php?mode=viewprofile&u=21729",

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -20,6 +20,8 @@ ltn-depot-reset-filters=Depots reset filters
 ltn-depot-fluid-cleaning=Depot fluid removal limit
 ltn-stop-default-network=Default network ID
 
+ltn-legacy-output-behavior=Legacy output behavior
+
 [mod-setting-description]
 ltn-interface-console-level=Detail level of in game messages.\n\n0: Off\nNo messages will be generated.\n\n1: Errors & Warnings\nPrint only errors and warnings.\n\n2: Notifications (default)\nPrint basic information like missing resources or generating deliveries.\n\n3: Detailed Messages\nPrint detailed information about finding providers and trains.
 ltn-interface-message-filter-age=Message age in ticks before filtered messages are shown again.\ndefault = 18000
@@ -40,6 +42,8 @@ ltn-dispatcher-finish-loading=True: (default)\nPrevents trains from leaving whil
 ltn-depot-reset-filters=True: (default)\nCargo wagons have their filters and stack limitations cleared when entering a depot.
 ltn-depot-fluid-cleaning=Maximum amount of fluid per wagon automatically destroyed when entering depots.\nSet to 0 to disable.
 ltn-stop-default-network=Network ID used for stops without "Encoded Network ID" signal.
+
+ltn-legacy-output-behavior=True: (default)\nOutput combinator returns the contents of the train that are not included in the request (including what the inserters will have time to drop if something hangs in them).\n\nFalse:\nOutput combinator only returns the query. When delivery, returns -1.
 
 [string-mod-setting]
 #<setting-name>-<dropdown-item-name>=<translated item>

--- a/settings.lua
+++ b/settings.lua
@@ -156,4 +156,11 @@ data:extend({
     setting_type = "runtime-global",
     default_value = -1, -- any
   },
+  {
+    type = "bool-setting",
+    name = "ltn-legacy-output-behavior",
+    order = "fa",
+    setting_type = "runtime-global",
+    default_value = true,
+  },
 })


### PR DESCRIPTION
…Can be disabled for backward compatible. Disabled by default.

Now the Output combinator is introducing some confusion. It reflects the request, but it also reflects the contents of the train that arrived at the supply station in the same way.

I'm proposing a fix for this issue and a setting to allow legacy games to be played.