### PR TITLE
Output combinator only returns the query. When delivery, returns -1. …

### DIFF
--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -20,6 +20,8 @@ ltn-depot-reset-filters=Depots reset filters
 ltn-depot-fluid-cleaning=Depot fluid removal limit
 ltn-stop-default-network=Default network ID
 
+ltn-legacy-output-behavior=Legacy output behavior
+
 [mod-setting-description]
 ltn-interface-console-level=Detail level of in game messages.\n\n0: Off\nNo messages will be generated.\n\n1: Errors & Warnings\nPrint only errors and warnings.\n\n2: Notifications (default)\nPrint basic information like missing resources or generating deliveries.\n\n3: Detailed Messages\nPrint detailed information about finding providers and trains.
 ltn-interface-message-filter-age=Message age in ticks before filtered messages are shown again.\ndefault = 18000
@@ -40,6 +42,8 @@ ltn-dispatcher-finish-loading=True: (default)\nPrevents trains from leaving whil
 ltn-depot-reset-filters=True: (default)\nCargo wagons have their filters and stack limitations cleared when entering a depot.
 ltn-depot-fluid-cleaning=Maximum amount of fluid per wagon automatically destroyed when entering depots.\nSet to 0 to disable.
 ltn-stop-default-network=Network ID used for stops without "Encoded Network ID" signal.
+
+ltn-legacy-output-behavior=True: (default)\nOutput combinator returns the contents of the train that are not included in the request (including what the inserters will have time to drop if something hangs in them).\n\nFalse:\nOutput combinator only returns the query. When delivery, returns -1.
 
 [string-mod-setting]
 #<setting-name>-<dropdown-item-name>=<translated item>

--- a/script/settings.lua
+++ b/script/settings.lua
@@ -27,6 +27,7 @@ end
 depot_reset_filters = settings.global["ltn-depot-reset-filters"].value
 depot_fluid_cleaning = settings.global["ltn-depot-fluid-cleaning"].value
 default_network = settings.global["ltn-stop-default-network"].value
+output_legacy_behavior = settings.global["ltn-legacy-output-behavior"].value
 
 
 script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
@@ -98,5 +99,8 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
   end
   if event.setting == "ltn-stop-default-network" then
     default_network = settings.global["ltn-stop-default-network"].value
+  end
+  if event.setting == "ltn-legacy-output-behavior" then
+    output_legacy_behavior = settings.global["ltn-legacy-output-behavior"].value
   end
 end)

--- a/script/stop-update.lua
+++ b/script/stop-update.lua
@@ -375,8 +375,15 @@ function UpdateStopOutput(trainStop)
     local carriages = trainStop.parked_train.carriages
     local encoded_positions_by_name = {}
     local encoded_positions_by_type = {}
-    local inventory = trainStop.parked_train.get_contents() or {}
-    local fluidInventory = trainStop.parked_train.get_fluid_contents() or {}
+    local inventory
+    local fluidInventory
+    if output_legacy_behavior then
+      inventory = trainStop.parked_train.get_contents() or {}
+      fluidInventory = trainStop.parked_train.get_fluid_contents() or {}
+    else
+      inventory = {}
+      fluidInventory = {}
+    end
 
     if #carriages < 32 then --prevent circuit network integer overflow error
       if trainStop.parked_train_faces_stop then --train faces forwards >> iterate normal
@@ -434,7 +441,11 @@ function UpdateStopOutput(trainStop)
             if c.type == "item_count" then
               if (c.condition.comparator == "=" and c.condition.constant == 0) then
                 --train expects to be unloaded of each of this item
-                inventory[c.condition.first_signal.name] = nil
+                if output_legacy_behavior then
+                  inventory[c.condition.first_signal.name] = nil
+                else
+                  inventory[c.condition.first_signal.name] = -1
+                end
               elseif c.condition.comparator == "≥" then
                 --train expects to be loaded to x of this item
                 inventory[c.condition.first_signal.name] = c.condition.constant

--- a/settings.lua
+++ b/settings.lua
@@ -156,4 +156,11 @@ data:extend({
     setting_type = "runtime-global",
     default_value = -1, -- any
   },
+  {
+    type = "bool-setting",
+    name = "ltn-legacy-output-behavior",
+    order = "fa",
+    setting_type = "runtime-global",
+    default_value = true,
+  },
 })


### PR DESCRIPTION
…Can be disabled for backward compatible. Disabled by default.

Now the Output combinator is introducing some confusion. It reflects the request, but it also reflects the contents of the train that arrived at the supply station in the same way.

I'm proposing a fix for this issue and a setting to allow legacy games to be played.