### PR TITLE
Add option to hide rich text descriptions

### DIFF
--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -2,6 +2,7 @@
 ltn-interface-console-level=Message level
 ltn-interface-message-filter-age=Message filter timeout (ticks)
 ltn-interface-message-gps=GPS tags
+ltn-interface-message-hide-rich-items=Hide rich text descriptions for items and fluids
 ltn-interface-factorio-alerts=Factorio Alerts
 ltn-interface-debug-logfile=Enable debug log
 

--- a/script/settings.lua
+++ b/script/settings.lua
@@ -8,6 +8,7 @@
 message_level = tonumber(settings.global["ltn-interface-console-level"].value)
 message_filter_age = settings.global["ltn-interface-message-filter-age"].value
 message_include_gps = settings.global["ltn-interface-message-gps"].value
+message_hide_rich_items = settings.global["ltn-interface-message-hide-rich-items"].value
 debug_log = settings.global["ltn-interface-debug-logfile"].value
 min_requested = settings.global["ltn-dispatcher-requester-threshold"].value
 min_provided = settings.global["ltn-dispatcher-provider-threshold"].value
@@ -40,6 +41,9 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
   end
   if event.setting == "ltn-interface-message-gps" then
     message_include_gps = settings.global["ltn-interface-message-gps"].value
+  end
+  if event.setting == "ltn-interface-message-hide-rich-items" then
+    message_hide_rich_items = settings.global["ltn-interface-message-hide-rich-items"].value
   end
   if event.setting == "ltn-interface-debug-logfile" then
     debug_log = settings.global["ltn-interface-debug-logfile"].value

--- a/script/utils.lua
+++ b/script/utils.lua
@@ -42,6 +42,10 @@ end
 
 -- returns gps string from entity or just string if entity is invalid
 function MakeGpsString(entity, name)
+  if message_hide_rich_items then
+    name = string.gsub(name, "%[item=", "[img=item/")
+    name = string.gsub(name, "%[fluid=", "[img=fluid/")
+  end
   if message_include_gps and entity and entity.valid then
     return format("%s [gps=%s,%s,%s]", name, entity.position["x"], entity.position["y"], entity.surface.name)
   else

--- a/settings.lua
+++ b/settings.lua
@@ -56,15 +56,22 @@ data:extend({
   },
   {
     type = "bool-setting",
-    name = "ltn-interface-factorio-alerts",
+    name = "ltn-interface-message-hide-rich-items",
     order = "ag",
+    setting_type = "runtime-global",
+    default_value = false
+  },
+  {
+    type = "bool-setting",
+    name = "ltn-interface-factorio-alerts",
+    order = "ah",
     setting_type = "runtime-per-user",
     default_value = true
   },
   {
     type = "bool-setting",
     name = "ltn-interface-debug-logfile",
-    order = "ah",
+    order = "ai",
     setting_type = "runtime-global",
     default_value = false
   },


### PR DESCRIPTION
According to this suggestion: https://forums.factorio.com/viewtopic.php?f=214&t=82823

This options allows to replace `[item=` or `[fluid=` with `[img=item/` or `[img=fluid/` in train stop names so that it doesn't clutter the chat.

Note that german locale needs to be updated.