### PR TITLE
If a stop dies, turn the lamp and combinator into ghosts

### DIFF
--- a/script/init.lua
+++ b/script/init.lua
@@ -260,7 +260,7 @@ local function registerEvents()
 
   script.on_event( defines.events.on_pre_player_mined_item, OnEntityRemoved, filters_on_mined )
   script.on_event( defines.events.on_robot_pre_mined, OnEntityRemoved, filters_on_mined )
-  script.on_event( defines.events.on_entity_died, function(event) OnEntityRemoved(event, true) end, filters_on_mined )
+  script.on_event( defines.events.on_entity_died, OnEntityRemoved, filters_on_mined )
   script.on_event( defines.events.script_raised_destroy, OnEntityRemoved )
 
   script.on_event( {defines.events.on_pre_surface_deleted, defines.events.on_pre_surface_cleared }, OnSurfaceRemoved )

--- a/script/init.lua
+++ b/script/init.lua
@@ -260,7 +260,7 @@ local function registerEvents()
 
   script.on_event( defines.events.on_pre_player_mined_item, OnEntityRemoved, filters_on_mined )
   script.on_event( defines.events.on_robot_pre_mined, OnEntityRemoved, filters_on_mined )
-  script.on_event( defines.events.on_entity_died, OnEntityRemoved, filters_on_mined )
+  script.on_event( defines.events.on_entity_died, function(event) OnEntityRemoved(event, true) end, filters_on_mined )
   script.on_event( defines.events.script_raised_destroy, OnEntityRemoved )
 
   script.on_event( {defines.events.on_pre_surface_deleted, defines.events.on_pre_surface_cleared }, OnSurfaceRemoved )

--- a/script/stop-events.lua
+++ b/script/stop-events.lua
@@ -181,7 +181,7 @@ end
 
 
 -- stop removed
-function RemoveStop(stopID, ghosts)
+function RemoveStop(stopID, create_ghosts)
   local stop = global.LogisticTrainStops[stopID]
 
   -- clean lookup tables
@@ -201,7 +201,7 @@ function RemoveStop(stopID, ghosts)
   -- destroy IO entities, broken IO entities should be sufficiently handled in initializeTrainStops()
   if stop then
     if stop.input and stop.input.valid then
-      if ghosts then
+      if create_ghosts then
         stop.input.destructible = true
         stop.input.die()
       else
@@ -209,7 +209,7 @@ function RemoveStop(stopID, ghosts)
       end
     end
     if stop.output and stop.output.valid then
-      if ghosts then
+      if create_ghosts then
         stop.output.destructible = true
         stop.output.die()
       else
@@ -235,7 +235,7 @@ function RemoveStop(stopID, ghosts)
   end
 end
 
-function OnEntityRemoved(event, ghosts)
+function OnEntityRemoved(event)
   local entity = event.entity
   if not entity or not entity.valid then return end
 
@@ -254,7 +254,7 @@ function OnEntityRemoved(event, ghosts)
     end
 
   elseif ltn_stop_entity_names[entity.name] then
-    RemoveStop(entity.unit_number, ghosts)
+    RemoveStop(entity.unit_number, true)
   end
 end
 

--- a/script/stop-events.lua
+++ b/script/stop-events.lua
@@ -235,7 +235,7 @@ function RemoveStop(stopID, create_ghosts)
   end
 end
 
-function OnEntityRemoved(event)
+function OnEntityRemoved(event, create_ghosts)
   local entity = event.entity
   if not entity or not entity.valid then return end
 
@@ -254,7 +254,7 @@ function OnEntityRemoved(event)
     end
 
   elseif ltn_stop_entity_names[entity.name] then
-    RemoveStop(entity.unit_number, true)
+    RemoveStop(entity.unit_number, create_ghosts)
   end
 end
 

--- a/script/stop-events.lua
+++ b/script/stop-events.lua
@@ -181,7 +181,7 @@ end
 
 
 -- stop removed
-function RemoveStop(stopID)
+function RemoveStop(stopID, ghosts)
   local stop = global.LogisticTrainStops[stopID]
 
   -- clean lookup tables
@@ -200,8 +200,22 @@ function RemoveStop(stopID)
 
   -- destroy IO entities, broken IO entities should be sufficiently handled in initializeTrainStops()
   if stop then
-    if stop.input and stop.input.valid then stop.input.destroy() end
-    if stop.output and stop.output.valid then stop.output.destroy() end
+    if stop.input and stop.input.valid then
+      if ghosts then
+        stop.input.destructible = true
+        stop.input.die()
+      else
+        stop.input.destroy()
+      end
+    end
+    if stop.output and stop.output.valid then
+      if ghosts then
+        stop.output.destructible = true
+        stop.output.die()
+      else
+        stop.output.destroy()
+      end
+    end
     if stop.lamp_control and stop.lamp_control.valid then stop.lamp_control.destroy() end
   end
 
@@ -221,7 +235,7 @@ function RemoveStop(stopID)
   end
 end
 
-function OnEntityRemoved(event)
+function OnEntityRemoved(event, ghosts)
   local entity = event.entity
   if not entity or not entity.valid then return end
 
@@ -240,7 +254,7 @@ function OnEntityRemoved(event)
     end
 
   elseif ltn_stop_entity_names[entity.name] then
-    RemoveStop(entity.unit_number)
+    RemoveStop(entity.unit_number, ghosts)
   end
 end
 


### PR DESCRIPTION
Currently when a stop falls victim of a biter attack (or gets nuked by a space exploration weapon delivery cannon 🙃)
the construction robots happily rebuild the stop, but sadly it won't have any of the wire automatically reconnected.

This pull request will make it so that if the train stop entity dies a `ghosts = true` property will propogate through the functions and have the input & outputs die instead, causing them to turn into ghosts if the force has it enabled, the other ways the entity can cease to exist keep the normal/nil ghost behavior of destroying them all instead.

(of course the ghosts from` .die()` preserve their wires & the station create listener already revives any lamp ghosts)

The name is of course up for debate, i wasn't sure which you would prefer:
- ghosts
- die_instead_of_destroy
- makeGhosts
- ioGhosts
- revivable
- etc

This problem happened before when i was looking, but today i noticed stuck production lines since 1 station was down.