### PR TITLE
Move `train.schedule =` to below dispatcher table changes

### DIFF
--- a/script/dispatcher.lua
+++ b/script/dispatcher.lua
@@ -688,10 +688,6 @@ function ProcessRequest(reqIndex, request)
   end
   schedule.records[#schedule.records + 1] = NewScheduleRecord(to, "item_count", "=", loadingList, 0)
 
-  -- log("DEBUG: schedule = "..serpent.block(schedule))
-  selectedTrain.schedule = schedule
-
-
   local shipment = {}
   if debug_log then log("Creating Delivery: "..totalStacks.." stacks, "..from.." >> "..to) end
   for i=1, #loadingList do
@@ -759,6 +755,9 @@ function ProcessRequest(reqIndex, request)
       end
     end
   end
+  
+  -- log("DEBUG: schedule = "..serpent.block(schedule))
+  selectedTrain.schedule = schedule
 
   return selectedTrain.id -- deliveries are indexed by train.id
 end


### PR DESCRIPTION
Before 1.18.x one had to rely on the `on_delivery_created` event to know when a train has been sent out, it was not possible to rely just on the basegame `on_train_schedule_changed` event since that gets called right when `train.schedule` changed and the event wouldn't be sent out until after this large function was done.

Now with the removal of that event since 1.18.x it seems logical (to me) that if you wish to know if a train that had just had its schedule set was done so by LTN to call this within the `on_train_schedule_changed` event:
`script.on_event(remote.call("logistic-train-network", "get_next_logistic_stop"), handler)`

Without the change this pull request suggests, any mod would have to store the train from the `on_train_schedule_changed` event in a table with save/load support for just 1 tick since the remote call wouldn't have the most recent changes to `global.Dispatcher.Deliveries` yet.

Setting the schedule at the end of this function (and thus below `global.Dispatcher.Deliveries[selectedTrain.id] =`) would remove a lot of complexity from mods that depend on knowing ASAP if a train is working for LTN or not.

Waiting on the next `on_dispatcher_updated` is not an option since the time in between grows larger and larger for megabases (unless of course those players finetune the map option), but in terms of ASAP it simply is not.

So in short, please move `train.schedule =` to below the `global.Dispatcher[` changes, wouldn't mind if its above or below the set lamps 🙂 