### PR TITLE
Added upgrade planner functionality

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -63,3 +63,10 @@ end
 
 data.raw["constant-combinator"]["logistic-train-stop-output"].item_slot_count = 4 + lococount + wagoncount + wagoncount_fluid + wagoncount_artillery + itemcount + fluidcount
 log(string.format("[LTN] found %d items, %d fluids, %d locomotives, %d cargo wagons, %d fluid wagons, %d artillery wagons.", itemcount, fluidcount, lococount, wagoncount, wagoncount_fluid, wagoncount_artillery))
+
+data.raw["train-stop"]["train-stop"].fast_replaceable_group = "train-stop"
+data.raw["train-stop"]["logistic-train-stop"].fast_replaceable_group = "train-stop"
+data.raw["train-stop"]["train-stop"].next_upgrade = "logistic-train-stop"
+data.raw["train-stop"]["logistic-train-stop"].next_upgrade = "train-stop"
+
+

--- a/data.lua
+++ b/data.lua
@@ -11,4 +11,10 @@ require ("prototypes.items")
 require ("prototypes.entities")
 require ("prototypes.signals")
 require ("prototypes.hotkeys")
+require ("prototypes.upgrade-item")
+
 flib = nil
+
+
+  
+  

--- a/prototypes/upgrade-item.lua
+++ b/prototypes/upgrade-item.lua
@@ -1,0 +1,27 @@
+data:extend({
+    {
+      type = "item-subgroup",
+      name = "trainstop-upgrade",
+      group = "logistics",
+      order = "b",
+    },
+    {
+      type = "upgrade-item",
+      name = "trainstop-upgrade",
+      icon = "__LogisticTrainNetwork__/graphics/icons/train-stop.png",
+      icon_size = 64, icon_mipmaps = 4,
+      subgroup = "trainstop-upgrade",
+      order = "a[train-stop]-b[logistic]",
+      stack_size = 1,
+      stackable = false,
+      draw_label_for_cursor_render = true,
+      selection_color = {0, 1, 0},
+      alt_selection_color = {0.7, 0.7, 0},
+      selection_mode = {"any-entity"},
+      alt_selection_mode = {"any-entity"},
+      selection_cursor_box_type = "copy",
+      alt_selection_cursor_box_type = "copy",
+      upgrade_target = "logistic-train-stop",
+      upgrade_from = {"train-stop"}
+    },
+  })


### PR DESCRIPTION
Heya, I took a stab at upgradeable functionality for upgrading normal train stations to logistic train stations.

Should hopefully work both through the upgrade planner as well as simple placing a logistic train station over a regular train station.

