### PR TITLE
Separate wait until full/empty

### DIFF
--- a/locale/de/settings.cfg
+++ b/locale/de/settings.cfg
@@ -14,7 +14,8 @@ ltn-dispatcher-depot-inactivity(s)=Depotinaktivität (Sek.)
 ltn-dispatcher-stop-timeout(s)=maximale Ladedauer (Sek.)
 ltn-dispatcher-delivery-timeout(s)=maximale Lieferzeit (Sek.)
 ltn-dispatcher-requester-delivery-reset=Fahrplan bei Anforderer abschließen
-ltn-dispatcher-finish-loading=Beladung abschließen
+ltn-dispatcher-finish-unloading=Beladung abschließen
+ltn-dispatcher-finish-loading=Eintrag abgeschlossenßen
 ltn-depot-reset-filters=Waggonfilter in Depots löschen
 ltn-depot-fluid-cleaning=Automatisch entfernte Flüssigkeitsmenge
 ltn-stop-default-network=Standard Netzwerk ID
@@ -36,7 +37,8 @@ ltn-dispatcher-depot-inactivity(s)=Dauer in Sekunden, bevor Züge das Depot wege
 ltn-dispatcher-stop-timeout(s)=Dauer in Sekunden bevor Züge ihre Station verlassen müssen.\n0 schaltet diese Funktion aus.\nStandardwert = 120s
 ltn-dispatcher-delivery-timeout(s)=Lieferzeit in Sekunden bevor Züge als vermisst gelten.\nStandardwert = 600s (10min)
 ltn-dispatcher-requester-delivery-reset=Inaktiv: (Standardwert)\nLieferung und Fahrplan werden bei Ankunft im Depot zurück gesetzt.\nÄnderungen an Zügen in Anforderer-Haltestellen haben keine Auswirkung.\n\nAktiv:\nLieferung und Fahrplan werden bei verlassen der Anforderer-Haltestelle zurück gesetzt.\nÄnderungen an Zügen in Anforderer-Haltestellen löscht die Lieferung und setzt den Fahrplan zurück.
-ltn-dispatcher-finish-loading=Aktiv: (Standardwert)\nVerhindert verlassen von Haltestellen während Greifarme/Pumpen arbeiten.\n\nInaktiv:\nZüge verlassen Haltestellen unmittelbar nach erreichen ihrer gewünschten Beladung.\nGreifarme bleiben Gegenstände haltend stecken, Tankwaggons enthalten Restmengen.
+ltn-dispatcher-finish-unloading=Aktiv: (Standardwert)\n(Entladung)Verhindert verlassen von Haltestellen während Greifarme/Pumpen arbeiten.\n\nInaktiv:\nZüge verlassen Haltestellen unmittelbar nach erreichen ihrer gewünschten Beladung.\nGreifarme bleiben Gegenstände haltend stecken, Tankwaggons enthalten Restmengen.
+ltn-dispatcher-finish-loading=Aktiv: (Standardwert)\n(Wird geladen)Verhindert verlassen von Haltestellen während Greifarme/Pumpen arbeiten.\n\nInaktiv:\nZüge verlassen Haltestellen unmittelbar nach erreichen ihrer gewünschten Beladung.\nGreifarme bleiben Gegenstände haltend stecken, Tankwaggons enthalten Restmengen.
 ltn-depot-reset-filters=Aktiv: (Standardwert)\nFilter und Stapelbegrenzungen in Güterwaggons werden bei Ankunft im Depot gelöscht.
 ltn-depot-fluid-cleaning=Maximale Flüssigkeitsmenge pro Waggon die bei Ankunft im Depot automatisch zerstört wird.\n0 schaltet diese Funktion aus.
 ltn-stop-default-network=Netzwerk ID wenn kein Signal "Kodierte Netzwerk ID" existiert.

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -15,6 +15,7 @@ ltn-dispatcher-depot-inactivity(s)=Depot inactivity (sec)
 ltn-dispatcher-stop-timeout(s)=Stop timeout (sec)
 ltn-dispatcher-delivery-timeout(s)=Delivery timeout (sec)
 ltn-dispatcher-requester-delivery-reset=Delivery completes at requester
+ltn-dispatcher-finish-unloading=Finish unloading
 ltn-dispatcher-finish-loading=Finish loading
 ltn-depot-reset-filters=Depots reset filters
 ltn-depot-fluid-cleaning=Depot fluid removal limit
@@ -37,6 +38,7 @@ ltn-dispatcher-depot-inactivity(s)=Duration in seconds of inactivity before trai
 ltn-dispatcher-stop-timeout(s)=Duration in seconds before trains are forced out of a station.\n0 deactivates this feature.\ndefault = 120
 ltn-dispatcher-delivery-timeout(s)=Duration in seconds deliveries can take before assuming the train was lost.\ndefault = 600 (10min)
 ltn-dispatcher-requester-delivery-reset=False: (default)\nDelivery and schedule are reset when train arrives at depot.\nChanges to trains parked at requesting stops have no effect.\n\nTrue:\nDelivery and schedule are reset when train leaves requester.\nChanges to trains parked at requesting stops will remove delivery and reset schedule.
+ltn-dispatcher-finish-unloading=True: (default)\nPrevents trains from leaving while inserters/pumps are unloading by adding 2s inactivity condition.\n\nFalse:\nTrains will leave immediately when all items have been unloaded.\nInserters at unloading stations will get stuck.
 ltn-dispatcher-finish-loading=True: (default)\nPrevents trains from leaving while inserters/pumps are working by adding 2s inactivity condition.\n\nFalse:\nTrains will leave immediately when all items have been loaded.\nInserters at loading stations will get stuck.
 ltn-depot-reset-filters=True: (default)\nCargo wagons have their filters and stack limitations cleared when entering a depot.
 ltn-depot-fluid-cleaning=Maximum amount of fluid per wagon automatically destroyed when entering depots.\nSet to 0 to disable.

--- a/script/dispatcher.lua
+++ b/script/dispatcher.lua
@@ -235,11 +235,14 @@ function NewScheduleRecord(stationName, condType, condComp, itemlist, countOverr
       -- itemlist = {first_signal.type, first_signal.name, constant}
       local cond = {comparator = condComp, first_signal = {type = itemlist[i].type, name = itemlist[i].name}, constant = countOverride or itemlist[i].count}
       record.wait_conditions[#record.wait_conditions+1] = {type = condFluid or condType, compare_type = "and", condition = cond }
+      if finish_unloading and condComp == "=" and countOverride == 0 then
+        record.wait_conditions[#record.wait_conditions+1] = condition_finish_loading
+      end
     end
 
     if waitEmpty then
       record.wait_conditions[#record.wait_conditions+1] = condition_wait_empty
-    elseif finish_loading then -- let inserter/pumps finish
+    elseif finish_loading and not (condComp == "=" and countOverride == 0) then
       record.wait_conditions[#record.wait_conditions+1] = condition_finish_loading
     end
 

--- a/script/settings.lua
+++ b/script/settings.lua
@@ -16,6 +16,7 @@ depot_inactivity = settings.global["ltn-dispatcher-depot-inactivity(s)"].value *
 stop_timeout = settings.global["ltn-dispatcher-stop-timeout(s)"].value * 60
 condition_stop_timeout = {type = "time", compare_type = "or", ticks = stop_timeout }
 delivery_timeout = settings.global["ltn-dispatcher-delivery-timeout(s)"].value * 60
+finish_unloading = settings.global["ltn-dispatcher-finish-unloading"].value
 finish_loading = settings.global["ltn-dispatcher-finish-loading"].value
 requester_delivery_reset = settings.global["ltn-dispatcher-requester-delivery-reset"].value
 dispatcher_enabled = settings.global["ltn-dispatcher-enabled"].value
@@ -62,6 +63,9 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
   end
   if event.setting == "ltn-dispatcher-delivery-timeout(s)" then
     delivery_timeout = settings.global["ltn-dispatcher-delivery-timeout(s)"].value * 60
+  end
+  if event.setting == "ltn-dispatcher-finish-unloading" then
+    finish_unloading = settings.global["ltn-dispatcher-finish-unloading"].value
   end
   if event.setting == "ltn-dispatcher-finish-loading" then
     finish_loading = settings.global["ltn-dispatcher-finish-loading"].value

--- a/settings.lua
+++ b/settings.lua
@@ -129,6 +129,13 @@ data:extend({
   },
   {
     type = "bool-setting",
+    name = "ltn-dispatcher-finish-unloading",
+    order = "cf",
+    setting_type = "runtime-global",
+    default_value = true
+  },
+  {
+    type = "bool-setting",
     name = "ltn-dispatcher-finish-loading",
     order = "cf",
     setting_type = "runtime-global",


### PR DESCRIPTION
The 2 second idle delay may now be specified separately for pickup and delivery stations.
Resolves: https://github.com/0ptera/Logistic-Train-Network/issues/336